### PR TITLE
logischer fehler in isCompatibleWithAutosomalRecessive() 

### DIFF
--- a/src/main/java/jannovar/pedigree/Pedigree.java
+++ b/src/main/java/jannovar/pedigree/Pedigree.java
@@ -772,7 +772,8 @@ public class Pedigree {
 	ArrayList<GenotypeCall> maternal = new ArrayList<GenotypeCall> ();
 
 	if (this.parentList.size()>2) {
-	    throw new UnsupportedOperationException("Autosomal recessive pedigree analysis with more than two parents is not supported!");
+		return false;
+//	    throw new UnsupportedOperationException("Autosomal recessive pedigree analysis with more than two parents is not supported!");
 	}
 
 	for (Variant v : varList) {


### PR DESCRIPTION
Why the method isCompatibleWithAutosomalRecessive() throws an error, when its not recessive...

Dominant analysis will not work on larger pedigrees for the exomiser. So returning false instead of throwing error

Best,
Max
