### PR TITLE
Adding support for multiple variant types per annotation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 **develop**
 
+*jannovar-cli*
+
 * Adding `-v` and `-vv` command line options.
+* Fixing problems with block substitution (delins) case (#87).
+
+*jannovar-core*
+
+* Reordering values of `VariantType`.
+* Somewhat renaming `VariantType` method names. 
+* Removing the `VariantType#size` function in favor of a `static public`
+  `final` member.
 * Using log4j/slf4j for I/O in jannovar-core.
 * Adding `PrintStream` as parameter to `JannovarOptions#print`.
 * Compressing serialized file.
-* Fixing problems with block substitution (delins) case (#87).
 * Changing namespace to `de.charite.compbio.jannovar`.
 * Making `VariantType#priorityLevel` a non-static member.
 * Renaming `TranscriptInfo` to `TranscriptModel`.

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/JannovarAnnotationCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/JannovarAnnotationCommand.java
@@ -39,13 +39,9 @@ public abstract class JannovarAnnotationCommand extends JannovarCommand {
 	 *             when the user requested the help page
 	 */
 	protected void deserializeTranscriptDefinitionFile() throws JannovarException, HelpRequestedException {
-		final long startTime = System.nanoTime();
 		JannovarData data = new JannovarDataSerializer(this.options.dataFile).load();
 		this.refDict = data.refDict;
 		this.chromosomeMap = data.chromosomes;
-		final long endTime = System.nanoTime();
-		System.err.println(String.format("Deserialization took %.2f sec.",
-				(endTime - startTime) / 1000.0 / 1000.0 / 1000.0));
 	}
 
 }

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotateVCFCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotateVCFCommand.java
@@ -37,7 +37,6 @@ public class AnnotateVCFCommand extends JannovarAnnotationCommand {
 		System.err.println("Options");
 		options.print(System.err);
 
-		System.err.println("Deserializing transcripts...");
 		deserializeTranscriptDefinitionFile();
 
 		for (String vcfPath : options.vcfFilePaths) {

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotatedJannovarWriter.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotatedJannovarWriter.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 
 import de.charite.compbio.jannovar.JannovarOptions;
@@ -124,7 +125,7 @@ public class AnnotatedJannovarWriter extends AnnotatedVariantWriter {
 		}
 
 		for (Annotation a : anno.entries) {
-			String effect = a.varType.toString();
+			String effect = Joiner.on("+").join(a.varTypes);
 			String annt = a.hgvsDescription;
 			String sym = a.transcript.geneSymbol;
 			String s = String.format("%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\t%.1f\n", currentLine, effect, sym, annt,

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotatedVCFWriter.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotatedVCFWriter.java
@@ -164,14 +164,14 @@ public class AnnotatedVCFWriter extends AnnotatedVariantWriter {
 					hgvsText.append(gen.buildHGVSText());
 				}
 			} else {
-				AnnotationList bestList = null;  // by pathogenicity
+				AnnotationList bestList = null; // by pathogenicity
 				for (AnnotationList annoList : annoLists) {
 					if (annoList.entries.isEmpty())
 						continue;
 					if (bestList == null)
 						bestList = annoList;
-					else if (annoList.entries.get(0).varType.priorityLevel() < bestList.entries.get(0).varType
-							.priorityLevel())
+					else if (annoList.entries.get(0).getMostPathogenicVarType().priorityLevel() < bestList.entries
+							.get(0).getMostPathogenicVarType().priorityLevel())
 						bestList = annoList;
 				}
 				if (bestList != null) {
@@ -187,7 +187,6 @@ public class AnnotatedVCFWriter extends AnnotatedVariantWriter {
 			if (hgvsText.length() > 0)
 				vc.getCommonInfo().putAttribute("HGVS", hgvsText.toString(), true);
 		}
-
 
 		// Write out variantContext to out.
 		out.add(vc);

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationCollector.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationCollector.java
@@ -215,7 +215,7 @@ final class AnnotationCollector {
 		VariantType vt;
 		Collections.sort(this.annotationLst);
 		Annotation a = this.annotationLst.get(0);
-		return a.varType;
+		return a.getMostPathogenicVarType();
 	}
 
 	/**
@@ -283,10 +283,11 @@ final class AnnotationCollector {
 	 */
 	public void addExonicAnnotation(Annotation ann) {
 		this.annotationLst.add(ann);
-		if (ann.varType == VariantType.SYNONYMOUS) {
+		if (ann.getMostPathogenicVarType() == VariantType.SYNONYMOUS) {
 			this.hasSynonymous = true;
-		} else if (ann.varType == VariantType.SPLICE_DONOR || ann.varType == VariantType.SPLICE_ACCEPTOR
-				|| ann.varType == VariantType.SPLICE_REGION) {
+		} else if (ann.getMostPathogenicVarType() == VariantType.SPLICE_DONOR
+				|| ann.getMostPathogenicVarType() == VariantType.SPLICE_ACCEPTOR
+				|| ann.getMostPathogenicVarType() == VariantType.SPLICE_REGION) {
 			this.hasSplicing = true;
 		} else {
 			this.hasExonic = true;
@@ -320,16 +321,17 @@ final class AnnotationCollector {
 	 */
 	public void addIntronicAnnotation(Annotation ann) {
 		this.geneSymbolSet.add(ann.transcript.geneSymbol);
-		if (ann.varType == VariantType.INTRONIC || ann.varType == VariantType.ncRNA_INTRONIC) {
+		if (ann.getMostPathogenicVarType() == VariantType.INTRONIC
+				|| ann.getMostPathogenicVarType() == VariantType.ncRNA_INTRONIC) {
 			for (Annotation a : this.annotationLst) {
 				if (a.equals(ann))
 					return; /* already have identical annotation */
 			}
 			this.annotationLst.add(ann);
 		}
-		if (ann.varType == VariantType.INTRONIC) {
+		if (ann.getMostPathogenicVarType() == VariantType.INTRONIC) {
 			this.hasIntronic = true;
-		} else if (ann.varType == VariantType.ncRNA_INTRONIC) {
+		} else if (ann.getMostPathogenicVarType() == VariantType.ncRNA_INTRONIC) {
 			this.hasNcrnaIntronic = true;
 		}
 		this.hasGenicMutation = true;
@@ -376,7 +378,7 @@ final class AnnotationCollector {
 				return;
 		}
 		this.annotationLst.add(ann);
-		VariantType type = ann.varType;
+		VariantType type = ann.getMostPathogenicVarType();
 		if (type == VariantType.DOWNSTREAM) {
 			this.hasDownstream = true;
 		} else if (type == VariantType.UPSTREAM) {

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationListContentDecorator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationListContentDecorator.java
@@ -41,7 +41,7 @@ public class AnnotationListContentDecorator {
 	 */
 	public boolean hasStructuralVariant() {
 		for (Annotation entry : annotations.entries)
-			if (entry.varType.isSV())
+			if (entry.getMostPathogenicVarType().isSV())
 				return true;
 		return false;
 	}
@@ -75,7 +75,7 @@ public class AnnotationListContentDecorator {
 		if (annotations.entries.size() == 0)
 			return null;
 		else
-			return annotations.entries.get(0).varType;
+			return annotations.entries.get(0).getMostPathogenicVarType();
 	}
 
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationListTextGenerator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationListTextGenerator.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.annotation;
 
+import com.google.common.base.Joiner;
+
 import de.charite.compbio.jannovar.impl.util.StringUtil;
 
 // TODO(holtgrem): Test me!
@@ -46,7 +48,7 @@ public abstract class AnnotationListTextGenerator {
 				builder.append(',');
 			if (altCount > 1)
 				builder.append(StringUtil.concatenate("alt", alleleID + 1, ":"));
-			builder.append(anno.varType);
+			builder.append(Joiner.on("+").join(anno.varTypes));
 		}
 		return builder.toString();
 	}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationVariantTypeDecorator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationVariantTypeDecorator.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.annotation;
 
+import com.google.common.collect.ImmutableList;
+
 // TODO(holtgrem): Test me!
 
 /**
@@ -23,52 +25,33 @@ final public class AnnotationVariantTypeDecorator {
 	 */
 	public boolean isCodingExonic() {
 		// TODO(holtgrem): Are the first three ones correct?
-		switch (this.annotation.varType) {
-		case SPLICE_DONOR:
-		case SPLICE_ACCEPTOR:
-		case SPLICE_REGION:
-		case STOPLOSS:
-		case STOPGAIN:
-		case SYNONYMOUS:
-		case MISSENSE:
-		case NON_FS_SUBSTITUTION:
-		case NON_FS_INSERTION:
-		case FS_SUBSTITUTION:
-		case FS_DELETION:
-		case FS_INSERTION:
-		case NON_FS_DELETION:
-			return true;
-		default:
-			return false;
-		}
+		ImmutableList<VariantType> tryMatch = ImmutableList.of(VariantType.STOPLOSS, VariantType.STOPGAIN,
+				VariantType.SYNONYMOUS, VariantType.MISSENSE, VariantType.NON_FS_SUBSTITUTION,
+				VariantType.NON_FS_INSERTION, VariantType.FS_SUBSTITUTION, VariantType.FS_DELETION,
+				VariantType.FS_INSERTION, VariantType.NON_FS_DELETION);
+		for (VariantType v : tryMatch)
+			if (annotation.varTypes.contains(v))
+				return true;
+		return false;
 	}
 
 	/**
 	 * @return <code>true</code> if this annotation is for a 3' or 5' UTR
 	 */
 	public boolean isUTRVariant() {
-		switch (this.annotation.varType) {
-		case UTR3:
-		case UTR5:
-			return true;
-		default:
-			return false;
-		}
+		return (annotation.varTypes.contains(VariantType.UTR3) || annotation.varTypes.contains(VariantType.UTR5));
 	}
 
 	/**
 	 * @return <code>true</code> if the variant affects an exon of an ncRNA
 	 */
 	public boolean isNonCodingRNA() {
-		switch (this.annotation.varType) {
-		case ncRNA_EXONIC:
-		case ncRNA_INTRONIC:
-		case ncRNA_SPLICE_DONOR:
-		case ncRNA_SPLICE_ACCEPTOR:
-		case ncRNA_SPLICE_REGION:
-			return true;
-		default:
-			return false;
-		}
+		ImmutableList<VariantType> tryMatch = ImmutableList.of(VariantType.ncRNA_EXONIC, VariantType.ncRNA_INTRONIC,
+				VariantType.ncRNA_SPLICE_DONOR, VariantType.ncRNA_SPLICE_ACCEPTOR, VariantType.ncRNA_SPLICE_REGION);
+		for (VariantType v : tryMatch)
+			if (annotation.varTypes.contains(v))
+				return true;
+		return false;
 	}
+
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantType.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantType.java
@@ -1,92 +1,142 @@
 package de.charite.compbio.jannovar.annotation;
 
-// TODO(holtgrem): Use higher priority resolution internvally (e.g. 1/1000th)? This way we could remove any ambiguities.
-
 /**
- * These codes reflect the possible types of variants that we call for an exome. Note that the codes have the obvious
- * meanings, but UTR53 means a variant that is in the 3' UTR of one transcript and the 5' UTR of another transcript.
+ * These codes reflect the possible types of variants that we call for an exome.
  *
- * Note that the an intergenic variant is considered UPSTREAM or DOWNSTREAM if it is within 1000 nucleotides of a gene,
- * otherwise INTERGENIC. This behavior is controlled by the constant NEARGENE in {@link de.charite.compbio.jannovar.io.Chromosome
- * Chromosome}. Note that this class implements the assignment of a priority level to the variant classes. See the
- * document for the class {@link de.charite.compbio.jannovar.annotation.AnnotationCollector AnnotatedVariantFactory} for details.
+ * Note that the codes have the obvious meanings, but UTR53 means a variant that is in the 3' UTR of one transcript and
+ * the 5' UTR of another transcript.
  *
+ * The values in this enum are given in the putative order of severity (more severe to less severe).
  *
  * @author Peter Robinson <peter.robinson@charite.de>
  * @author Marten Jaeger <marten.jaeger@charite.de>
+ * @author Manuel Holtgrewe <manuel.holtgrewe@charite.de>
  */
 // TODO(mjaeger): the outputnames for structural variants...
 public enum VariantType {
-	/** whole exon los, SO:"A feature ablation whereby the deleted region includes a transcript feature */
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 1
+	// ----------------------------------------------------------------------
+
+	/** whole exon loss, SO:"A feature ablation whereby the deleted region includes a transcript feature */
 	TRANSCRIPT_ABLATION,
-	/** variant is downstream of a gene */
-	DOWNSTREAM,
-	/** deletion resulting in a frameshift */
-	FS_DELETION,
+	/** variant is a structural deletion variant &gt;=1000bp */
+	SV_DELETION,
+	/** variant is a structural insertion variant &gt;=1000bp */
+	SV_INSERTION,
+	/** variant is a structural substitution variant &gt;=1000bp */
+	SV_SUBSTITUTION,
+	/** variant is a structural inversion variant &gt;=1000bp */
+	SV_INVERSION,
+
+	/** variant located changing the 2 base region at the 3' end of an intron */
+	SPLICE_DONOR,
+	/** variant located changing the 2 base region at the 5' end of an intron */
+	SPLICE_ACCEPTOR,
+	/** variant that induces a new stop codon (i.e., nonsense) */
+	STOPGAIN,
+	/** nucleotide duplication that results in a frameshift */
+	FS_DUPLICATION,
 	/** insertion resulting in a frameshift */
 	FS_INSERTION,
-	/** nucleotide substitution that does not result in a frameshift */
-	NON_FS_SUBSTITUTION,
+	/** deletion resulting in a frameshift */
+	FS_DELETION,
 	/** nucleotide substitution that results in a frameshift */
 	FS_SUBSTITUTION,
-	/** variant located between two genes (far enough away not to qualify as upstream/downstream) */
-	INTERGENIC,
-	/** variant located in an intron */
-	INTRONIC,
+	/** variant that alters and removes a wildtype stop codon */
+	STOPLOSS,
+	/** variation leads to the loss of the start codon */
+	START_LOSS,
+	/** nucleotide duplication that does not result in a frameshift */
+	NON_FS_DUPLICATION,
+	/** insertion that does not result in a frameshift */
+	NON_FS_INSERTION,
+	/** deletion that does not result in a frameshift */
+	NON_FS_DELETION,
+	/** nucleotide substitution that does not result in a frameshift */
+	NON_FS_SUBSTITUTION,
 	/**
 	 * Variant that leads to the substitution of one amino acid (note this was earlier "NONYSYNONYMOUS" but the term
 	 * name was changed to conform with the terminology of the <a href="http://www.sequenceontology.org/">Sequence
 	 * Ontology</a>).
 	 */
 	MISSENSE,
+	/** variant either located in 1-3 bases of an exon or 3-8 bases of an intron */
+	SPLICE_REGION,
+	/** A sequence variant where at least one base in the terminator codon is changed, but the terminator remains */
+	STOP_RETAINED,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 2
+	// ----------------------------------------------------------------------
+
 	/** variant located in an exon of a noncoding RNA gene */
 	ncRNA_EXONIC,
-	/** variant located in an intron of a noncoding RNA gene */
-	ncRNA_INTRONIC,
 	/** variant located in a splice donor region of a non-coding gene */
 	ncRNA_SPLICE_DONOR,
 	/** variant located in a splice donor region of a non-coding gene */
 	ncRNA_SPLICE_ACCEPTOR,
 	/** variant located in a splice donor region of a non-coding gene */
 	ncRNA_SPLICE_REGION,
-	/** deletion that does not result in a frameshift */
-	NON_FS_DELETION,
-	/** insertion that does not result in a frameshift */
-	NON_FS_INSERTION,
-	/** variant located changing the 2 base region at the 5' end of an intron */
-	SPLICE_ACCEPTOR,
-	/** variant located changing the 2 base region at the 3' end of an intron */
-	SPLICE_DONOR,
-	/** variant either located in 1-3 bases of an exon or 3-8 bases of an intron */
-	SPLICE_REGION,
-	/** variant that induces a new stop codon (i.e., nonsense) */
-	STOPGAIN,
-	/** variant that alters and removes a wildtype stop codon */
-	STOPLOSS,
-	/** nucleotide substitution that does not alter the encoded amino acid of the affected codon */
-	SYNONYMOUS,
-	/** variant is upstream of a gene */
-	UPSTREAM,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 3
+	// ----------------------------------------------------------------------
+
 	/** variant is located in the 3' untranslated region */
 	UTR3,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 4
+	// ----------------------------------------------------------------------
+
 	/** variant is located in the 5' untranslated region */
 	UTR5,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 5
+	// ----------------------------------------------------------------------
+
+	/** nucleotide substitution that does not alter the encoded amino acid of the affected codon */
+	SYNONYMOUS,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 6
+	// ----------------------------------------------------------------------
+
+	/** variant located in an intron */
+	INTRONIC,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 7
+	// ----------------------------------------------------------------------
+
+	/** variant located in an intron of a noncoding RNA gene */
+	ncRNA_INTRONIC,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 8
+	// ----------------------------------------------------------------------
+
+	/** variant is downstream of a gene */
+	DOWNSTREAM,
+	/** variant is upstream of a gene */
+	UPSTREAM,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 9
+	// ----------------------------------------------------------------------
+
+	/** variant located between two genes (far enough away not to qualify as upstream/downstream) */
+	INTERGENIC,
+
+	// ----------------------------------------------------------------------
+	// PRIORITY LEVEL = 10
+	// ----------------------------------------------------------------------
+
 	/** variant assessed as probably erroneous (may indicate an error in the VCF file) */
-	ERROR,
-	/** nucleotide duplication that does not result in a frameshift */
-	NON_FS_DUPLICATION,
-	/** nucleotide duplication that results in a frameshift */
-	FS_DUPLICATION,
-	/** variation leads to the loss of the start codon */
-	START_LOSS,
-	/** variant is a structural insertion variant &gt;=1000bp */
-	SV_INSERTION,
-	/** variant is a structural deletion variant &gt;=1000bp */
-	SV_DELETION,
-	/** variant is a structural substitution variant &gt;=1000bp */
-	SV_SUBSTITUTION,
-	/** variant is a structural inversion variant &gt;=1000bp */
-	SV_INVERSION;
+	ERROR;
 
 	/**
 	 * The preference level for annotations is
@@ -124,6 +174,7 @@ public enum VariantType {
 		case SPLICE_DONOR:
 		case SPLICE_ACCEPTOR:
 		case SPLICE_REGION:
+		case STOP_RETAINED:
 		case STOPGAIN:
 		case STOPLOSS:
 		case FS_DUPLICATION:
@@ -176,22 +227,6 @@ public enum VariantType {
 	}
 
 	/**
-	 * This returns an array with the VariantTypes arranged according to their priority. It can used to arrange output
-	 * of Variants ranked according to presumed pathogenicity.
-	 *
-	 * @return an array with the VariantTypes priority sorted
-	 */
-	public static VariantType[] getPrioritySortedList() {
-		VariantType[] vta = new VariantType[] { TRANSCRIPT_ABLATION, SV_DELETION, SV_INSERTION, SV_SUBSTITUTION,
-				SV_INVERSION, MISSENSE, STOPGAIN, SPLICE_DONOR, SPLICE_ACCEPTOR, SPLICE_REGION, FS_DELETION,
-				FS_INSERTION, FS_SUBSTITUTION, NON_FS_DELETION, NON_FS_INSERTION, NON_FS_SUBSTITUTION, STOPLOSS,
-				FS_DUPLICATION, NON_FS_DUPLICATION, START_LOSS, ncRNA_EXONIC, ncRNA_SPLICE_DONOR,
-				ncRNA_SPLICE_ACCEPTOR, ncRNA_SPLICE_REGION, UTR3, UTR5, SYNONYMOUS, INTRONIC, ncRNA_INTRONIC, UPSTREAM,
-				DOWNSTREAM, INTERGENIC, ERROR };
-		return vta;
-	}
-
-	/**
 	 * A string representing the variant type (e.g., missense_variant, stop_gained,...)
 	 *
 	 * @return Name of this {@link VariantType}
@@ -220,6 +255,8 @@ public enum VariantType {
 			return "splice acceptor";
 		case SPLICE_REGION:
 			return "splice region";
+		case STOP_RETAINED:
+			return "stop retained";
 		case STOPGAIN:
 			return "stopgain";
 		case STOPLOSS:
@@ -298,6 +335,8 @@ public enum VariantType {
 			return "splice_acceptor_variant";
 		case SPLICE_REGION:
 			return "splice_region_variant";
+		case STOP_RETAINED:
+			return "stop_retained";
 		case STOPGAIN:
 			return "stop_gained";
 		case STOPLOSS:
@@ -376,6 +415,8 @@ public enum VariantType {
 			return "SO:0001574";
 		case SPLICE_REGION:
 			return "SO:0001630";
+		case STOP_RETAINED:
+			return "SO:0001567";
 		case STOPGAIN:
 			return "SO:0001587";
 		case STOPLOSS:
@@ -435,11 +476,6 @@ public enum VariantType {
 	/**
 	 * A static constant that returns the number of different values in this enumeration.
 	 */
-	private static final int size = VariantType.values().length;
-
-	/** @return the number of different values in this enumeration. */
-	public static int size() {
-		return VariantType.size;
-	}
+	public static final int size = VariantType.values().length;
 
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
+import java.util.ArrayList;
+
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.VariantType;
 import de.charite.compbio.jannovar.impl.util.StringUtil;
@@ -125,34 +127,36 @@ abstract class AnnotationBuilder {
 		GenomePosition pos = changeInterval.getGenomeBeginPos();
 		int txBeginPos = projector.projectGenomeToCDSPosition(pos).pos;
 
+		ArrayList<VariantType> varTypes = new ArrayList<VariantType>();
 		if (changeInterval.length() == 0) {
 			GenomePosition lPos = pos.shifted(-1);
-			VariantType varType;
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if ((so.liesInSpliceDonorSite(lPos) && so.liesInSpliceDonorSite(pos)))
-				varType = VariantType.ncRNA_SPLICE_DONOR;
+				varTypes.add(VariantType.ncRNA_SPLICE_DONOR);
 			else if ((so.liesInSpliceAcceptorSite(lPos) && so.liesInSpliceAcceptorSite(pos)))
-				varType = VariantType.ncRNA_SPLICE_ACCEPTOR;
+				varTypes.add(VariantType.ncRNA_SPLICE_ACCEPTOR);
 			else if ((so.liesInSpliceRegion(lPos) && so.liesInSpliceRegion(pos)))
-				varType = VariantType.ncRNA_SPLICE_REGION;
-			else if (so.liesInExon(lPos) && so.liesInExon(pos))
-				varType = VariantType.ncRNA_EXONIC;
+				varTypes.add(VariantType.ncRNA_SPLICE_REGION);
+			// Check for being in intron/exon.
+			if (so.liesInExon(lPos) && so.liesInExon(pos))
+				varTypes.add(VariantType.ncRNA_EXONIC);
 			else
-				varType = VariantType.ncRNA_INTRONIC;
-			return new Annotation(varType, txBeginPos, ncHGVS(), transcript);
+				varTypes.add(VariantType.ncRNA_INTRONIC);
 		} else {
-			VariantType varType;
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varType = VariantType.ncRNA_SPLICE_DONOR;
+				varTypes.add(VariantType.ncRNA_SPLICE_DONOR);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varType = VariantType.ncRNA_SPLICE_ACCEPTOR;
+				varTypes.add(VariantType.ncRNA_SPLICE_ACCEPTOR);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varType = VariantType.ncRNA_SPLICE_REGION;
-			else if (so.overlapsWithExon(changeInterval))
-				varType = VariantType.ncRNA_EXONIC;
+				varTypes.add(VariantType.ncRNA_SPLICE_REGION);
+			// Check for being in intron/exon.
+			if (so.overlapsWithExon(changeInterval))
+				varTypes.add(VariantType.ncRNA_EXONIC);
 			else
-				varType = VariantType.ncRNA_INTRONIC;
-			return new Annotation(varType, txBeginPos, ncHGVS(), transcript);
+				varTypes.add(VariantType.ncRNA_INTRONIC);
 		}
+		return new Annotation(varTypes, txBeginPos, ncHGVS(), transcript);
 	}
 
 	/**
@@ -164,29 +168,28 @@ abstract class AnnotationBuilder {
 		GenomePosition pos = change.getGenomeInterval().getGenomeBeginPos();
 		int txBeginPos = projector.projectGenomeToCDSPosition(pos).pos;
 
-		VariantType varType;
+		ArrayList<VariantType> varTypes = new ArrayList<VariantType>();
+		varTypes.add(VariantType.INTRONIC); // always include intronic as variant type
 		if (change.getGenomeInterval().length() == 0) {
 			GenomePosition lPos = pos.shifted(-1);
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if ((so.liesInSpliceDonorSite(lPos) && so.liesInSpliceDonorSite(pos)))
-				varType = VariantType.SPLICE_DONOR;
+				varTypes.add(VariantType.SPLICE_DONOR);
 			else if ((so.liesInSpliceAcceptorSite(lPos) && so.liesInSpliceAcceptorSite(pos)))
-				varType = VariantType.SPLICE_ACCEPTOR;
+				varTypes.add(VariantType.SPLICE_ACCEPTOR);
 			else if ((so.liesInSpliceRegion(lPos) && so.liesInSpliceRegion(pos)))
-				varType = VariantType.SPLICE_REGION;
-			else
-				varType = VariantType.INTRONIC;
+				varTypes.add(VariantType.SPLICE_REGION);
 		} else {
 			GenomeInterval changeInterval = change.getGenomeInterval();
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varType = VariantType.SPLICE_DONOR;
+				varTypes.add(VariantType.SPLICE_DONOR);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varType = VariantType.SPLICE_ACCEPTOR;
+				varTypes.add(VariantType.SPLICE_ACCEPTOR);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varType = VariantType.SPLICE_REGION;
-			else
-				varType = VariantType.INTRONIC;
+				varTypes.add(VariantType.SPLICE_REGION);
 		}
-		return new Annotation(varType, txBeginPos, ncHGVS(), transcript);
+		return new Annotation(varTypes, txBeginPos, ncHGVS(), transcript);
 	}
 
 	/**
@@ -198,35 +201,39 @@ abstract class AnnotationBuilder {
 		GenomePosition pos = change.getGenomeInterval().getGenomeBeginPos();
 		int txBeginPos = projector.projectGenomeToCDSPosition(pos).pos;
 
-		VariantType varType;
+		ArrayList<VariantType> varTypes = new ArrayList<VariantType>();
 		if (change.getGenomeInterval().length() == 0) {
 			GenomePosition lPos = pos.shifted(-1);
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if ((so.liesInSpliceDonorSite(lPos) && so.liesInSpliceDonorSite(pos)))
-				varType = VariantType.SPLICE_DONOR;
+				varTypes.add(VariantType.SPLICE_DONOR);
 			else if ((so.liesInSpliceAcceptorSite(lPos) && so.liesInSpliceAcceptorSite(pos)))
-				varType = VariantType.SPLICE_ACCEPTOR;
+				varTypes.add(VariantType.SPLICE_ACCEPTOR);
 			else if ((so.liesInSpliceRegion(lPos) && so.liesInSpliceRegion(pos)))
-				varType = VariantType.SPLICE_REGION;
-			else if (so.liesInFivePrimeUTR(lPos))
-				varType = VariantType.UTR5;
+				varTypes.add(VariantType.SPLICE_REGION);
+			// Check for being in 5' or 3' UTR.
+			if (so.liesInFivePrimeUTR(lPos))
+				varTypes.add(VariantType.UTR5);
 			else
 				// so.liesInThreePrimeUTR(pos)
-				varType = VariantType.UTR3;
+				varTypes.add(VariantType.UTR3);
 		} else {
 			GenomeInterval changeInterval = change.getGenomeInterval();
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varType = VariantType.SPLICE_DONOR;
+				varTypes.add(VariantType.SPLICE_DONOR);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varType = VariantType.SPLICE_ACCEPTOR;
+				varTypes.add(VariantType.SPLICE_ACCEPTOR);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varType = VariantType.SPLICE_REGION;
-			else if (so.overlapsWithFivePrimeUTR(change.getGenomeInterval()))
-				varType = VariantType.UTR5;
+				varTypes.add(VariantType.SPLICE_REGION);
+			// Check for being in 5' or 3' UTR.
+			if (so.overlapsWithFivePrimeUTR(change.getGenomeInterval()))
+				varTypes.add(VariantType.UTR5);
 			else
 				// so.overlapsWithThreePrimeUTR(change.getGenomeInterval())
-				varType = VariantType.UTR3;
+				varTypes.add(VariantType.UTR3);
 		}
-		return new Annotation(varType, txBeginPos, ncHGVS(), transcript);
+		return new Annotation(varTypes, txBeginPos, ncHGVS(), transcript);
 	}
 
 	/**

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
@@ -119,7 +119,7 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 			protAnno = "p.0?";
 		} else if (so.overlapsWithTranslationalStopSite(changeInterval)) {
 			if (wtAA.equals(varAA)) { // change in stop codon, but no AA change
-				varTypes.add(VariantType.SYNONYMOUS); // TODO(holtgrem): should be STOP_RETAINED
+				varTypes.add(VariantType.STOP_RETAINED);
 			} else { // change in stop codon, AA change
 				varTypes.add(VariantType.STOPLOSS);
 				String varNTString = seqChangeHelper.getCDSWithChange(change);

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceOntologyDecorator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceOntologyDecorator.java
@@ -218,8 +218,8 @@ public final class TranscriptSequenceOntologyDecorator {
 	/**
 	 * Returns whether the given <code>interval</code> overlaps with a splice region.
 	 *
-	 * We define the splice region to be the first/last 3 bases of an exon (towards an intron) and the first/last 8
-	 * bases of an intron. Note that this <b>includes</b> the splice donor and acceptor sites.
+	 * A splice_region_variant is a sequence variant in which a change has occurred within the region of the splice
+	 * site, either within 1-3 bases of the exon or 3-8 bases of the intron.
 	 *
 	 * @param interval
 	 *            the {@link GenomeInterval} to use for querying
@@ -249,7 +249,8 @@ public final class TranscriptSequenceOntologyDecorator {
 	/**
 	 * Returns whether the given <code>pos</code> lies within a splice region.
 	 *
-	 * See {@link #overlapsWithSpliceRegion(GenomeInterval)} for the definition of <b>splice region</b>.
+	 * A splice_region_variant is a sequence variant in which a change has occurred within the region of the splice
+	 * site, either within 1-3 bases of the exon or 3-8 bases of the intron.
 	 *
 	 * @param pos
 	 *            the {@link GenomePosition} to use for querying
@@ -279,7 +280,7 @@ public final class TranscriptSequenceOntologyDecorator {
 	/**
 	 * Returns whether the given <code>interval</code> overlaps with a splice donor site.
 	 *
-	 * The splice donor site is the first two bases of an intron.
+	 * A splice variant that changes the 2 base pair region at the 5' end of an intron.
 	 *
 	 * @param interval
 	 *            the {@link GenomeInterval} to use for querying
@@ -299,7 +300,7 @@ public final class TranscriptSequenceOntologyDecorator {
 	/**
 	 * Returns whether the given <code>pos</code> lies within a splice donor site.
 	 *
-	 * The splice acceptor site is the last two bases of an intron.
+	 * A splice variant that changes the 2 base pair region at the 5' end of an intron.
 	 *
 	 * @param pos
 	 *            the {@link GenomePosition} to use for querying
@@ -319,7 +320,7 @@ public final class TranscriptSequenceOntologyDecorator {
 	/**
 	 * Returns whether the given <code>interval</code> overlaps with a splice acceptor site.
 	 *
-	 * The splice acceptor site is the last two bases of an intron.
+	 * A splice variant that changes the 2 base pair region at the 3' end of an intron.
 	 *
 	 * @param interval
 	 *            the {@link GenomeInterval} to use for querying
@@ -339,7 +340,7 @@ public final class TranscriptSequenceOntologyDecorator {
 	/**
 	 * Returns whether the given <code>pos</code> lies within a splice acceptor site.
 	 *
-	 * The splice acceptor site is the last two bases of an intron.
+	 * A splice variant that changes the 2 base pair region at the 3' end of an intron.
 	 *
 	 * @param pos
 	 *            the {@link GenomePosition} to use for querying

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSortedSet;
+
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeChange;
 import de.charite.compbio.jannovar.annotation.VariantType;
@@ -63,7 +65,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACG", "CGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=0", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UPSTREAM, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UPSTREAM), annotation1.varTypes);
 	}
 
 	@Test
@@ -72,7 +74,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACG", "CGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=0", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.DOWNSTREAM, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.DOWNSTREAM), annotation1.varTypes);
 	}
 
 	@Test
@@ -82,13 +84,13 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACG", "CGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=1000", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), annotation1.varTypes);
 		// intergenic downstream
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6650340, PositionType.ZERO_BASED),
 				"ACG", "CGTT");
 		Annotation annotation2 = new BlockSubstitutionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("dist=1000", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), annotation2.varTypes);
 	}
 
 	@Test
@@ -100,7 +102,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				chars200.toString(), "CGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.-204_-70+65delinsCGTT", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.TRANSCRIPT_ABLATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.TRANSCRIPT_ABLATION), annotation1.varTypes);
 	}
 
 	@Test
@@ -109,7 +111,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACG", "CGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-11_691-9delinsCGTT", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -118,7 +120,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACG", "CGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon1:c.-195_-193delinsCGTT", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -127,7 +129,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACG", "CGGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.*58_*60delinsCGGTT", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	@Test
@@ -139,21 +141,21 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACG", "CGTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1_3delinsCGTT:p.0?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1.varTypes);
 
 		// Delete chunk out of first exon, spanning start codon from the left.
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640660, PositionType.ZERO_BASED),
 				"CCCTCCAGACC", "GTTG");
 		Annotation annotation2 = new BlockSubstitutionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.-9_2delinsGTTG:p.0?", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2.varTypes);
 
 		// Delete chunk out of first exon, spanning start codon from the right.
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640671, PositionType.ZERO_BASED),
 				"GGACGGCTCCT", "CTTG");
 		Annotation annotation3 = new BlockSubstitutionAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_13delinsCTTG:p.0?", annotation3.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation3.varTypes);
 
 		// Deletion from before transcript, reaching into the start codon.
 		GenomeChange change4 = new GenomeChange(
@@ -162,7 +164,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"ACCT");
 		Annotation annotation4 = new BlockSubstitutionAnnotationBuilder(infoForward, change4).build();
 		Assert.assertEquals("uc001anx.3:c.-69-201_1delinsACCT:p.0?", annotation4.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation4.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation4.varTypes);
 	}
 
 	@Test
@@ -173,7 +175,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067_*2delinsCGTT:p.*689Tyrext*25", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
 
 		// Replace stop codon by 6 nucleotides, non-frameshift case.
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649270, PositionType.ZERO_BASED),
@@ -181,7 +183,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Annotation annotation2 = new BlockSubstitutionAnnotationBuilder(infoForward, change2).build();
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Assert.assertEquals("uc001anx.3:exon11:c.2066_*1delinsCGGTCG:p.*689Serext*17", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation2.varTypes);
 
 		// Delete first base of stop codon, leads to complete loss.
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649269, PositionType.ZERO_BASED),
@@ -189,7 +191,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Annotation annotation3 = new BlockSubstitutionAnnotationBuilder(infoForward, change3).build();
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Assert.assertEquals("uc001anx.3:exon11:c.2065_2067delinsCGGT:p.*689Argext*16", annotation3.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation3.varTypes);
 	}
 
 	@Test
@@ -199,14 +201,14 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"G", "TT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-1delinsTT", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 
 		// exonic splicing
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642117, PositionType.ZERO_BASED),
 				"TGG", "AA");
 		Annotation annotation2 = new BlockSubstitutionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.691_693delinsAA:p.Trp231Lysfs*23", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation2.varTypes);
 	}
 
 	@Test
@@ -216,7 +218,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TGCCCCACCT", "CCC");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon7:c.1225_1234delinsCCC:p.Cys409Profs*127", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -226,21 +228,21 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TAAACA", "GTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-3_693delinsGTT:p.Trp231Val", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 
 		// deletion of three codons, insertion of one
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642126, PositionType.ZERO_BASED),
 				"GTGGTTCAA", "ACC");
 		Annotation annotation2 = new BlockSubstitutionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.700_708delinsACC:p.Val234_Gln236delinsThr", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_SUBSTITUTION, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION), annotation2.varTypes);
 
 		// deletion of three codons, insertion of one, includes truncation of replacement ref from the right
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642134, PositionType.ZERO_BASED),
 				"AGTGGAGGAT", "CTT");
 		Annotation annotation3 = new BlockSubstitutionAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.708_716delinsCT:p.Gln236Hisfs*16", annotation3.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_SUBSTITUTION, annotation3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_SUBSTITUTION), annotation3.varTypes);
 	}
 
 	@Test
@@ -262,7 +264,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002axo.4:exon2:c.96_112delinsACTACCAGAGGAAT:p.Lys33_Met38delinsLeuProGluGluLeu",
 				annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_SUBSTITUTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION), annotation1.varTypes);
 	}
 
 	@Test
@@ -280,7 +282,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TCAACA", "ACAACACT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010qzf.2:exon1:c.713_718delinsACAACACT:p.Leu238Hisfs*19", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_SUBSTITUTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_SUBSTITUTION), annotation1.varTypes);
 	}
 
 	@Test
@@ -300,7 +302,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 156479564, PositionType.ZERO_BASED), "AGTCGT", "AGTGAG");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011ddm.2:exon4:c.475_477delinsCTC:p.Thr159Leu", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_SUBSTITUTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION), annotation1.varTypes);
 	}
 
 	@Test
@@ -322,7 +324,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002axo.4:exon2:c.96_112delinsACTACCAGAGGAAT:p.Lys33_Met38delinsLeuProGluGluLeu",
 				annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_SUBSTITUTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION), annotation1.varTypes);
 	}
 
 	@Test
@@ -342,7 +344,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 156479564, PositionType.ZERO_BASED), "AGTCGT", "GAGCTA");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011ddm.2:exon4:c.475_480delinsTAGCTC:p.Thr159*", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation1.varTypes);
 	}
 
 	@Test
@@ -362,7 +364,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 150771702, PositionType.ZERO_BASED), "TG", "CA");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001evp.2:exon7:c.830_831delinsTG:p.Ala277Val", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_SUBSTITUTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION), annotation1.varTypes);
 	}
 
 	// This change was in clinvar37 and made problems.
@@ -383,7 +385,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TGAGG", "C");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011ayb.2:c.1263_1266+1delinsC:p.Glu422del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	// Bug found #87 on GitHub
@@ -404,7 +406,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				PositionType.ONE_BASED), "GGTGATC", "A");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010nov.3:c.453_453+6delinsA:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
@@ -175,7 +175,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067_*2delinsCGTT:p.*689Tyrext*25", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION, VariantType.STOPLOSS),
+				annotation1.varTypes);
 
 		// Replace stop codon by 6 nucleotides, non-frameshift case.
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649270, PositionType.ZERO_BASED),
@@ -183,7 +184,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Annotation annotation2 = new BlockSubstitutionAnnotationBuilder(infoForward, change2).build();
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Assert.assertEquals("uc001anx.3:exon11:c.2066_*1delinsCGGTCG:p.*689Serext*17", annotation2.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation2.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_SUBSTITUTION, VariantType.STOPLOSS),
+				annotation2.varTypes);
 
 		// Delete first base of stop codon, leads to complete loss.
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649269, PositionType.ZERO_BASED),
@@ -191,7 +193,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Annotation annotation3 = new BlockSubstitutionAnnotationBuilder(infoForward, change3).build();
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Assert.assertEquals("uc001anx.3:exon11:c.2065_2067delinsCGGT:p.*689Argext*16", annotation3.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation3.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_SUBSTITUTION, VariantType.STOPLOSS),
+				annotation3.varTypes);
 	}
 
 	@Test
@@ -209,7 +212,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TGG", "AA");
 		Annotation annotation2 = new BlockSubstitutionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.691_693delinsAA:p.Trp231Lysfs*23", annotation2.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation2.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_SUBSTITUTION, VariantType.SPLICE_REGION),
+				annotation2.varTypes);
 	}
 
 	@Test
@@ -219,7 +223,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TGCCCCACCT", "CCC");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon7:c.1225_1234delinsCCC:p.Cys409Profs*127", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_SUBSTITUTION, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -229,7 +234,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TAAACA", "GTT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-3_693delinsGTT:p.Trp231Val", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 
 		// deletion of three codons, insertion of one
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642126, PositionType.ZERO_BASED),
@@ -345,7 +351,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 156479564, PositionType.ZERO_BASED), "AGTCGT", "GAGCTA");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011ddm.2:exon4:c.475_480delinsTAGCTC:p.Thr159*", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION, VariantType.STOPGAIN),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -386,7 +393,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"TGAGG", "C");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011ayb.2:c.1263_1266+1delinsC:p.Glu422del", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION, VariantType.SPLICE_DONOR),
+				annotation1.varTypes);
 	}
 
 	// Bug found #87 on GitHub
@@ -407,7 +415,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				PositionType.ONE_BASED), "GGTGATC", "A");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010nov.3:c.453_453+6delinsA:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION, VariantType.SPLICE_DONOR),
+				annotation1.varTypes);
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
@@ -201,7 +201,8 @@ public class BlockSubstitutionAnnotationBuilderTest {
 				"G", "TT");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-1delinsTT", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 
 		// exonic splicing
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642117, PositionType.ZERO_BASED),

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -5,10 +5,11 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSortedSet;
+
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeChange;
 import de.charite.compbio.jannovar.annotation.VariantType;
-import de.charite.compbio.jannovar.annotation.builders.DeletionAnnotationBuilder;
 import de.charite.compbio.jannovar.io.ReferenceDictionary;
 import de.charite.compbio.jannovar.reference.GenomeChange;
 import de.charite.compbio.jannovar.reference.GenomePosition;
@@ -65,7 +66,7 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=0", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UPSTREAM, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UPSTREAM), annotation1.varTypes);
 	}
 
 	@Test
@@ -74,7 +75,7 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=0", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.DOWNSTREAM, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.DOWNSTREAM), annotation1.varTypes);
 	}
 
 	@Test
@@ -84,13 +85,13 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=1000", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), annotation1.varTypes);
 		// intergenic downstream
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6650340, PositionType.ZERO_BASED),
 				"A", "");
 		Annotation annotation2 = new DeletionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("dist=1000", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), annotation2.varTypes);
 	}
 
 	@Test
@@ -102,7 +103,7 @@ public class DeletionAnnotationBuilderTest {
 				chars200.toString(), "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.-204_-70+65del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.TRANSCRIPT_ABLATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.TRANSCRIPT_ABLATION), annotation1.varTypes);
 	}
 
 	@Test
@@ -111,7 +112,7 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-11del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -120,7 +121,7 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon1:c.-192del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -129,7 +130,7 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.*59del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	@Test
@@ -141,21 +142,21 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1del:p.0?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1.varTypes);
 
 		// Delete chunk out of first exon, spanning start codon from the left.
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640660, PositionType.ZERO_BASED),
 				"CCCTCCAGACC", "");
 		Annotation annotation2 = new DeletionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.-9_2del:p.0?", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2.varTypes);
 
 		// Delete chunk out of first exon, spanning start codon from the right.
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640671, PositionType.ZERO_BASED),
 				"GGACGGCTCCT", "");
 		Annotation annotation3 = new DeletionAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_13del:p.0?", annotation3.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation3.varTypes);
 
 		// Deletion from before transcript, reaching into the start codon.
 		GenomeChange change4 = new GenomeChange(
@@ -164,7 +165,7 @@ public class DeletionAnnotationBuilderTest {
 				"");
 		Annotation annotation4 = new DeletionAnnotationBuilder(infoForward, change4).build();
 		Assert.assertEquals("uc001anx.3:c.-69-201_1del:p.0?", annotation4.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation4.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation4.varTypes);
 	}
 
 	@Test
@@ -177,35 +178,35 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067del:p.*689Tyrext*?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
 
 		// Delete middle base of stop codon, leads to complete loss.
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649270, PositionType.ZERO_BASED),
 				"A", "");
 		Annotation annotation2 = new DeletionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2066del:p.*689Cysext*?", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation2.varTypes);
 
 		// Delete first base of stop codon, leads to extension
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649269, PositionType.ZERO_BASED),
 				"A", "");
 		Annotation annotation3 = new DeletionAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2065del:p.*689Serext*?", annotation3.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation3.varTypes);
 
 		// Delete two bases of stop codon.
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649269, PositionType.ZERO_BASED),
 				"AT", "");
 		Annotation annotation4 = new DeletionAnnotationBuilder(infoForward, change4).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2065_2066del:p.*689Alaext*14", annotation4.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation4.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation4.varTypes);
 
 		// Delete from before into the stop codon.
 		GenomeChange change5 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649267, PositionType.ZERO_BASED),
 				"CATAGCCC", "");
 		Annotation annotation5 = new DeletionAnnotationBuilder(infoForward, change5).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2063_*3del:p.*689Hisext*13", annotation5.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation5.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation5.varTypes);
 	}
 
 	@Test
@@ -215,14 +216,14 @@ public class DeletionAnnotationBuilderTest {
 				"G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-1del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 
 		// exonic splicing
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642117, PositionType.ZERO_BASED),
 				"TGG", "");
 		Annotation annotation2 = new DeletionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.691_693del:p.Trp231del", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation2.varTypes);
 	}
 
 	@Test
@@ -232,7 +233,7 @@ public class DeletionAnnotationBuilderTest {
 				"TGGGGAGAAA", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon4:c.943_952del:p.Gly315Profs*26", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -243,21 +244,21 @@ public class DeletionAnnotationBuilderTest {
 				"GAAACA", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-3_693del:p.Trp231del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 
 		// deletion of three codons
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642126, PositionType.ZERO_BASED),
 				"GTGGTTCAA", "");
 		Annotation annotation2 = new DeletionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.704_712del:p.Val235_Val237del", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation2.varTypes);
 
 		// deletion of three codons, resulting in delins case
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642134, PositionType.ZERO_BASED),
 				"AGTGGAGGA", "");
 		Annotation annotation3 = new DeletionAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.708_716del:p.Gln236_Asp239delinsHis", annotation3.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation3.varTypes);
 	}
 
 	@Test
@@ -277,7 +278,7 @@ public class DeletionAnnotationBuilderTest {
 				"GCTGT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010ock.3:exon2:c.119_123del:p.Gln40Profs*18", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -295,7 +296,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 247978543, PositionType.ZERO_BASED), "GAG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001idm.1:exon1:c.488_490del:p.Ser163del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -315,7 +316,7 @@ public class DeletionAnnotationBuilderTest {
 				"TC", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011azx.2:exon4:c.1476_1477del:p.Asn494Profs*38", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -333,7 +334,7 @@ public class DeletionAnnotationBuilderTest {
 				"TGTAACCAC", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003dsi.1:exon1:c.369_377del:p.Val124_Thr126del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -351,7 +352,7 @@ public class DeletionAnnotationBuilderTest {
 				"TTTCCCTCTAT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011bgx.2:exon1:c.275_285del:p.Ile92Argfs*26", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -371,7 +372,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 140215470, PositionType.ZERO_BASED), "GCGCG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003lhq.2:exon1:c.1503_1507del:p.Glu501Aspfs*96", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -389,7 +390,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 140615503, PositionType.ZERO_BASED), "GTC", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003ljc.1:exon1:c.1219_1221del:p.Val407del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -407,7 +408,7 @@ public class DeletionAnnotationBuilderTest {
 				"T", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011dkw.2:exon1:c.985del:p.Thr329Leufs*17", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	/**
@@ -434,7 +435,7 @@ public class DeletionAnnotationBuilderTest {
 				"AAG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003ooo.3:exon2:c.324_326del:p.Phe109del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -454,7 +455,7 @@ public class DeletionAnnotationBuilderTest {
 				"AAG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003ooo.3:exon2:c.324_326del:p.Phe109del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -474,7 +475,7 @@ public class DeletionAnnotationBuilderTest {
 				"GTT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010mht.3:exon4:c.1542_1544del:p.Thr517del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -494,7 +495,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 10, 51768675, PositionType.ZERO_BASED), "AA", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001jix.4:exon8:c.791_792del:p.Lys264Argfs*10", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -514,7 +515,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 10, 51768774, PositionType.ZERO_BASED), "TGA", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001jix.4:exon8:c.890_892del:p.Leu297_Lys298delinsGln", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -532,7 +533,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 11, 56380553, PositionType.ZERO_BASED), "GACA", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001nja.1:exon1:c.422_425del:p.Cys141Serfs*21", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -552,7 +553,7 @@ public class DeletionAnnotationBuilderTest {
 				"G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001qui.2:exon6:c.377del:p.Pro126Glnfs*18", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -572,7 +573,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 123880923, PositionType.ZERO_BASED), "TT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001uew.3:exon5:c.542_543del:p.Leu181Hisfs*20", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -592,7 +593,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 13, 46170725, PositionType.ZERO_BASED), "ACTCTTCCTCCTCCAGAT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001val.2:exon3:c.404_421del:p.Glu135_Leu140del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -612,7 +613,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 15, 74536403, PositionType.ZERO_BASED), "AAG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002axo.4:exon2:c.100_102del:p.Lys34del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -632,7 +633,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 15, 78208898, PositionType.ZERO_BASED), "CTC", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010bky.2:exon14:c.842_844del:p.Glu281del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -653,7 +654,7 @@ public class DeletionAnnotationBuilderTest {
 				"G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002ghm.3:exon8:c.1310del:p.Gly437Valfs*5", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -673,7 +674,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 29161650, PositionType.ZERO_BASED), "GTCAAT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002hft.1:exon1:c.243_248del:p.Leu82_Gln83del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -693,7 +694,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 29161650, PositionType.ZERO_BASED), "GTCAAT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002hfs.1:exon2:c.552_557del:p.Ser185_Leu186del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	/**
@@ -717,7 +718,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 61660894, PositionType.ZERO_BASED), "G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002jbc.4:exon6:c.560del:p.Gly187Valfs*23", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -737,7 +738,7 @@ public class DeletionAnnotationBuilderTest {
 				"CC", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002wcx.3:exon2:c.317_318del:p.Pro106Argfs*?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -755,7 +756,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 21, 42551467, PositionType.ZERO_BASED), "GTGTCAGGGTGAGTGAGGG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002yyz.3:exon1:c.72_90del:p.Ser25Hisfs*78", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -775,7 +776,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 19, 58579807, PositionType.ZERO_BASED), "CCAGAG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002qrd.2:exon5:c.1152_1157del:p.His384_Arg386delinsGln", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION), annotation1.varTypes);
 	}
 
 	@Test
@@ -795,7 +796,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 11, 65793877, PositionType.ZERO_BASED), "A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001ogt.3:exon1:c.-25del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -815,7 +816,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 49525088, PositionType.ZERO_BASED), "CT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rtm.3:exon1:c.-7_-6del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -835,7 +836,7 @@ public class DeletionAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "AGCTGCG", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc004crz.3:exon2:c.-11_-5del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -855,7 +856,7 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001cjx.3:c.315-2del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -875,7 +876,7 @@ public class DeletionAnnotationBuilderTest {
 				"G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bak.1:exon10:c.1027del:p.Val343Trpfs*33", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -895,7 +896,7 @@ public class DeletionAnnotationBuilderTest {
 				"T", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc031rom.1:exon43:n.5842del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -912,7 +913,7 @@ public class DeletionAnnotationBuilderTest {
 				"T", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003nxo.1:exon1:n.26del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -932,7 +933,7 @@ public class DeletionAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc004fus.3:exon4:n.385del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	// This variant was called on the Platinum genomes and caused a problem with string access.
@@ -953,7 +954,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 9, 135782122, PositionType.ZERO_BASED), "TTCT", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011mcs.1:exon13:c.1068_1071del:p.Glu358del", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_DELETION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION), annotation1.varTypes);
 	}
 
 	// This variant was called on the Platinum genomes and caused a problem with string access.
@@ -973,7 +974,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 140812775, PositionType.ZERO_BASED), "T", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011dba.2:exon1:c.2461del:p.*821del?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -178,35 +178,36 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067del:p.*689Tyrext*?", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.STOPLOSS), annotation1.varTypes);
 
 		// Delete middle base of stop codon, leads to complete loss.
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649270, PositionType.ZERO_BASED),
 				"A", "");
 		Annotation annotation2 = new DeletionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2066del:p.*689Cysext*?", annotation2.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation2.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.STOPLOSS),
+				annotation2.varTypes);
 
 		// Delete first base of stop codon, leads to extension
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649269, PositionType.ZERO_BASED),
 				"A", "");
 		Annotation annotation3 = new DeletionAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2065del:p.*689Serext*?", annotation3.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation3.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.STOPLOSS), annotation3.varTypes);
 
 		// Delete two bases of stop codon.
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649269, PositionType.ZERO_BASED),
 				"AT", "");
 		Annotation annotation4 = new DeletionAnnotationBuilder(infoForward, change4).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2065_2066del:p.*689Alaext*14", annotation4.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation4.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.STOPLOSS), annotation4.varTypes);
 
 		// Delete from before into the stop codon.
 		GenomeChange change5 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649267, PositionType.ZERO_BASED),
 				"CATAGCCC", "");
 		Annotation annotation5 = new DeletionAnnotationBuilder(infoForward, change5).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2063_*3del:p.*689Hisext*13", annotation5.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation5.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.STOPLOSS), annotation5.varTypes);
 	}
 
 	@Test
@@ -224,7 +225,8 @@ public class DeletionAnnotationBuilderTest {
 				"TGG", "");
 		Annotation annotation2 = new DeletionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.691_693del:p.Trp231del", annotation2.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation2.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION, VariantType.SPLICE_REGION),
+				annotation2.varTypes);
 	}
 
 	@Test
@@ -245,7 +247,8 @@ public class DeletionAnnotationBuilderTest {
 				"GAAACA", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-3_693del:p.Trp231del", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DELETION, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 
 		// deletion of three codons
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642126, PositionType.ZERO_BASED),
@@ -655,7 +658,8 @@ public class DeletionAnnotationBuilderTest {
 				"G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002ghm.3:exon8:c.1310del:p.Gly437Valfs*5", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -719,7 +723,8 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 61660894, PositionType.ZERO_BASED), "G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002jbc.4:exon6:c.560del:p.Gly187Valfs*23", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -878,7 +883,8 @@ public class DeletionAnnotationBuilderTest {
 				"G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bak.1:exon10:c.1027del:p.Val343Trpfs*33", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.SPLICE_DONOR),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -976,7 +982,7 @@ public class DeletionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 140812775, PositionType.ZERO_BASED), "T", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011dba.2:exon1:c.2461del:p.*821del?", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_DELETION, VariantType.STOPLOSS), annotation1.varTypes);
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -216,7 +216,8 @@ public class DeletionAnnotationBuilderTest {
 				"G", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:c.691-1del", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 
 		// exonic splicing
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6642117, PositionType.ZERO_BASED),
@@ -856,7 +857,8 @@ public class DeletionAnnotationBuilderTest {
 				"A", "");
 		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001cjx.3:c.315-2del", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 	}
 
 	@Test

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -158,7 +158,8 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 6640670, PositionType.ZERO_BASED), "", "AGC");
 		Annotation annotation2agc = new InsertionAnnotationBuilder(infoForward, change2agc).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1_2insAGC:p.0?", annotation2agc.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2agc.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION, VariantType.START_LOSS),
+				annotation2agc.varTypes);
 
 		// Test cases where the start codon is not subjected to an insertion.
 
@@ -167,14 +168,16 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED), "", "TAA");
 		Annotation annotation3taa = new InsertionAnnotationBuilder(infoForward, change3taa).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insTAA:p.Asp2*", annotation3taa.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3taa.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION, VariantType.STOPGAIN),
+				annotation3taa.varTypes);
 
 		// Directly insert some base and then a stop codon.
 		GenomeChange change3tcctaa = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672,
 				PositionType.ZERO_BASED), "", "TCCTAA");
 		Annotation annotation3tcctaa = new InsertionAnnotationBuilder(infoForward, change3tcctaa).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insTCCTAA:p.Asp2_Gly3delinsSer", annotation3tcctaa.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3tcctaa.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION, VariantType.STOPGAIN),
+				annotation3tcctaa.varTypes);
 
 		// Insertion without a new stop codon that is no duplication.
 		GenomeChange change4tcctcctcc = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672,
@@ -182,7 +185,8 @@ public class InsertionAnnotationBuilderTest {
 		Annotation annotation4tcctcctcc = new InsertionAnnotationBuilder(infoForward, change4tcctcctcc).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insTCCTCCTCC:p.Met1_Asp2insSerSerSer",
 				annotation4tcctcctcc.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION), annotation4tcctcctcc.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION, VariantType.NON_FS_INSERTION),
+				annotation4tcctcctcc.varTypes);
 
 		// Insertion without a new stop codon that is a duplication.
 		GenomeChange change5gatggc = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672,
@@ -1077,8 +1081,8 @@ public class InsertionAnnotationBuilderTest {
 	/**
 	 * annovar: SCAMP1:uc003kfl.3:exon8:c.730_731insT:p.C244fs, chr5:77745856->T
 	 *
-	 * -- According to mutalyzer, p.(Asn244Ilefs*52), thus should be p.N244fs (this is what de.charite.compbio.jannovar says, annovar finds
-	 * a "C")
+	 * -- According to mutalyzer, p.(Asn244Ilefs*52), thus should be p.N244fs (this is what de.charite.compbio.jannovar
+	 * says, annovar finds a "C")
 	 */
 	@Test
 	public void testRealWorldCase_uc003kfl_3() throws InvalidGenomeChange {
@@ -1427,7 +1431,8 @@ public class InsertionAnnotationBuilderTest {
 		//
 		// The UCSC transcript DNA sequence is bogus here.
 		Assert.assertEquals("uc010hgj.1:exon4:c.590_591insAAGT:p.Leu197LeuSer*", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION, VariantType.STOPGAIN),
+				annotation1.varTypes);
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -129,7 +129,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "ACT");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.691-1_691insACT", anno.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), anno.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_REGION), anno.varTypes);
 	}
 
 	@Test

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -4,10 +4,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSortedSet;
+
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeChange;
 import de.charite.compbio.jannovar.annotation.VariantType;
-import de.charite.compbio.jannovar.annotation.builders.InsertionAnnotationBuilder;
 import de.charite.compbio.jannovar.io.ReferenceDictionary;
 import de.charite.compbio.jannovar.reference.GenomeChange;
 import de.charite.compbio.jannovar.reference.GenomePosition;
@@ -65,7 +66,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "A");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("dist=0", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.UPSTREAM, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UPSTREAM), anno.varTypes);
 	}
 
 	@Test
@@ -74,7 +75,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "A");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("dist=0", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.DOWNSTREAM, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.DOWNSTREAM), anno.varTypes);
 	}
 
 	@Test
@@ -84,14 +85,14 @@ public class InsertionAnnotationBuilderTest {
 				"", "A");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("dist=1000", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), anno.varTypes);
 
 		// downstream intergenic
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6650340, PositionType.ZERO_BASED),
 				"", "A");
 		Annotation anno2 = new InsertionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("dist=1000", anno2.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, anno2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), anno2.varTypes);
 	}
 
 	@Test
@@ -100,7 +101,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "A");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:c.1044+8_1044+9insA", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), anno.varTypes);
 	}
 
 	@Test
@@ -109,7 +110,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "C");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.-1dup", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), anno.varTypes);
 	}
 
 	@Test
@@ -118,7 +119,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "A");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067_*1insA", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), anno.varTypes);
 	}
 
 	@Test
@@ -128,7 +129,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "ACT");
 		Annotation anno = new InsertionAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon3:c.691-1_691insACT", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), anno.varTypes);
 	}
 
 	@Test
@@ -143,21 +144,21 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 6649271, PositionType.ZERO_BASED), "", "AGC");
 		Annotation annotation1agc = new InsertionAnnotationBuilder(infoForward, change1agc).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2066_2067insAGC:p.=", annotation1agc.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1agc.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1agc.varTypes);
 
 		// The WT stop codon is destroyed but there is a new one downstream
 		GenomeChange change1tgc = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 6649271, PositionType.ZERO_BASED), "", "TGC");
 		Annotation annotation1tgc = new InsertionAnnotationBuilder(infoForward, change1tgc).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2066_2067insTGC:p.*689Tyrext*24", annotation1tgc.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1tgc.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1tgc.varTypes);
 
 		// Test case where the start codon is destroyed.
 		GenomeChange change2agc = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 6640670, PositionType.ZERO_BASED), "", "AGC");
 		Annotation annotation2agc = new InsertionAnnotationBuilder(infoForward, change2agc).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1_2insAGC:p.0?", annotation2agc.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation2agc.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2agc.varTypes);
 
 		// Test cases where the start codon is not subjected to an insertion.
 
@@ -166,14 +167,14 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED), "", "TAA");
 		Annotation annotation3taa = new InsertionAnnotationBuilder(infoForward, change3taa).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insTAA:p.Asp2*", annotation3taa.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation3taa.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3taa.varTypes);
 
 		// Directly insert some base and then a stop codon.
 		GenomeChange change3tcctaa = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672,
 				PositionType.ZERO_BASED), "", "TCCTAA");
 		Annotation annotation3tcctaa = new InsertionAnnotationBuilder(infoForward, change3tcctaa).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insTCCTAA:p.Asp2_Gly3delinsSer", annotation3tcctaa.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation3tcctaa.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3tcctaa.varTypes);
 
 		// Insertion without a new stop codon that is no duplication.
 		GenomeChange change4tcctcctcc = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672,
@@ -181,14 +182,14 @@ public class InsertionAnnotationBuilderTest {
 		Annotation annotation4tcctcctcc = new InsertionAnnotationBuilder(infoForward, change4tcctcctcc).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insTCCTCCTCC:p.Met1_Asp2insSerSerSer",
 				annotation4tcctcctcc.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_INSERTION, annotation4tcctcctcc.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION), annotation4tcctcctcc.varTypes);
 
 		// Insertion without a new stop codon that is a duplication.
 		GenomeChange change5gatggc = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672,
 				PositionType.ZERO_BASED), "", "GATGGC");
 		Annotation annotation5gatggc = new InsertionAnnotationBuilder(infoForward, change5gatggc).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.5_6insTGGCGA:p.Asp2_Gly3dup", annotation5gatggc.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation5gatggc.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation5gatggc.varTypes);
 	}
 
 	@Test
@@ -200,13 +201,13 @@ public class InsertionAnnotationBuilderTest {
 				"", "G");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1_2insG:p.0?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640671, PositionType.ZERO_BASED),
 				"", "A");
 		Annotation annotation2 = new InsertionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.2_3insA:p.0?", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2.varTypes);
 
 		// Try to insert all non-duplicate NTs between 3 and 4.
 
@@ -214,19 +215,19 @@ public class InsertionAnnotationBuilderTest {
 				"", "A");
 		Annotation annotation3a = new InsertionAnnotationBuilder(infoForward, change3a).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insA:p.Asp2Argfs*37", annotation3a.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3a.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3a.varTypes);
 
 		GenomeChange change3c = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED),
 				"", "C");
 		Annotation annotation3c = new InsertionAnnotationBuilder(infoForward, change3c).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insC:p.Asp2Argfs*37", annotation3c.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3c.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3c.varTypes);
 
 		GenomeChange change3t = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED),
 				"", "T");
 		Annotation annotation3t = new InsertionAnnotationBuilder(infoForward, change3t).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insT:p.Asp2*", annotation3t.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation3t.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3t.varTypes);
 
 		// Try to insert all non-duplicate NTs between 4 and 5.
 
@@ -234,13 +235,13 @@ public class InsertionAnnotationBuilderTest {
 				"", "C");
 		Annotation annotation4c = new InsertionAnnotationBuilder(infoForward, change4c).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.4_5insC:p.Asp2Alafs*37", annotation4c.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation4c.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation4c.varTypes);
 
 		GenomeChange change4t = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640673, PositionType.ZERO_BASED),
 				"", "T");
 		Annotation annotation4t = new InsertionAnnotationBuilder(infoForward, change4t).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.4_5insT:p.Asp2Valfs*37", annotation4t.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation4t.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation4t.varTypes);
 
 		// Try to insert all non-duplicate NTs between 5 and 6.
 
@@ -248,13 +249,13 @@ public class InsertionAnnotationBuilderTest {
 				"", "G");
 		Annotation annotation5g = new InsertionAnnotationBuilder(infoForward, change5g).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.5_6insG:p.Asp2Glufs*37", annotation5g.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation5g.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation5g.varTypes);
 
 		GenomeChange change5t = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640674, PositionType.ZERO_BASED),
 				"", "T");
 		Annotation annotation5t = new InsertionAnnotationBuilder(infoForward, change5t).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.5_6insT:p.Gly3Argfs*36", annotation5t.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation5t.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation5t.varTypes);
 
 		// It appears to be impossible to force a stop loss for this transcript.
 
@@ -263,20 +264,20 @@ public class InsertionAnnotationBuilderTest {
 				"", "T");
 		Annotation annotation6t = new InsertionAnnotationBuilder(infoForward, change6t).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2066_2067insT:p.*689Tyrext*15", annotation6t.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation6t.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation6t.varTypes);
 
 		GenomeChange change6c = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649270, PositionType.ZERO_BASED),
 				"", "C");
 		Annotation annotation6c = new InsertionAnnotationBuilder(infoForward, change6c).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2065_2066insC:p.*689Serext*15", annotation6c.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation6c.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation6c.varTypes);
 
 		// Test for no change when inserting into stop codon.
 		GenomeChange change7g = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649270, PositionType.ZERO_BASED),
 				"", "G");
 		Annotation annotation7g = new InsertionAnnotationBuilder(infoForward, change7g).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2065_2066insG:p.=", annotation7g.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation7g.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation7g.varTypes);
 	}
 
 	@Test
@@ -288,13 +289,13 @@ public class InsertionAnnotationBuilderTest {
 				"", "GA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1_2insGA:p.0?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640671, PositionType.ZERO_BASED),
 				"", "AG");
 		Annotation annotation2 = new InsertionAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.2_3insAG:p.0?", annotation2.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2.varTypes);
 
 		// Try to insert some non-duplicate NT pairs between 3 and 4.
 
@@ -302,19 +303,19 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED), "", "AC");
 		Annotation annotation3ac = new InsertionAnnotationBuilder(infoForward, change3ac).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insAC:p.Asp2Thrfs*10", annotation3ac.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3ac.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3ac.varTypes);
 
 		GenomeChange change3cg = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED), "", "CG");
 		Annotation annotation3cg = new InsertionAnnotationBuilder(infoForward, change3cg).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insCG:p.Asp2Argfs*10", annotation3cg.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3cg.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3cg.varTypes);
 
 		GenomeChange change3ta = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED), "", "TA");
 		Annotation annotation3ta = new InsertionAnnotationBuilder(infoForward, change3ta).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3_4insTA:p.Asp2*", annotation3ta.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation3ta.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3ta.varTypes);
 
 		// Try to insert some non-duplicate NT pairs between 4 and 5.
 
@@ -322,13 +323,13 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 6640673, PositionType.ZERO_BASED), "", "CT");
 		Annotation annotation4ct = new InsertionAnnotationBuilder(infoForward, change4ct).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.4_5insCT:p.Asp2Alafs*10", annotation4ct.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3cg.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3cg.varTypes);
 
 		GenomeChange change4tg = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 6640673, PositionType.ZERO_BASED), "", "TG");
 		Annotation annotation4tg = new InsertionAnnotationBuilder(infoForward, change4tg).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.4_5insTG:p.Asp2Valfs*10", annotation4tg.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation3ta.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3ta.varTypes);
 
 		// Try to insert some non-duplicate NT pairs between 5 and 6.
 
@@ -336,13 +337,13 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 6640674, PositionType.ZERO_BASED), "", "GC");
 		Annotation annotation5gc = new InsertionAnnotationBuilder(infoForward, change5gc).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.5_6insGC:p.Asp2Glufs*10", annotation5gc.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation3ta.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation3ta.varTypes);
 
 		GenomeChange change5ta = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 6640674, PositionType.ZERO_BASED), "", "TA");
 		Annotation annotation5ta = new InsertionAnnotationBuilder(infoForward, change5ta).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.5_6insTA:p.Gly3Thrfs*9", annotation5ta.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3cg.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3cg.varTypes);
 	}
 
 	@Test
@@ -356,13 +357,13 @@ public class InsertionAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "", "ACTAGACT");
 		Annotation annotation4actagact = new InsertionAnnotationBuilder(infoForward, change4actagact).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.6_7insTAGACTAC:p.Gly3*", annotation4actagact.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation4actagact.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation4actagact.varTypes);
 
 		GenomeChange change4cgtg = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640673,
 				PositionType.ZERO_BASED), "", "CGTG");
 		Annotation annotation4cgtg = new InsertionAnnotationBuilder(infoForward, change4cgtg).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.4_5insCGTG:p.Asp2Alafs*2", annotation4cgtg.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation4cgtg.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation4cgtg.varTypes);
 	}
 
 	@Test
@@ -377,13 +378,13 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 23694497, PositionType.ZERO_BASED), "", "C");
 		Annotation annotation1c = new InsertionAnnotationBuilder(infoReverse, change1c).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.1_2insG:p.0?", annotation1c.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1c.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1c.varTypes);
 
 		GenomeChange change1g = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 23694497, PositionType.ZERO_BASED), "", "G");
 		Annotation annotation1g = new InsertionAnnotationBuilder(infoReverse, change1g).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.1_2insC:p.0?", annotation1g.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1g.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1g.varTypes);
 
 		// Insert A and C between nucleotides 2 and 3.
 
@@ -391,13 +392,13 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 23694496, PositionType.ZERO_BASED), "", "T");
 		Annotation annotation2a = new InsertionAnnotationBuilder(infoReverse, change2a).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.2_3insA:p.0?", annotation2a.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation2a.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2a.varTypes);
 
 		GenomeChange change2c = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 23694496, PositionType.ZERO_BASED), "", "G");
 		Annotation annotation2c = new InsertionAnnotationBuilder(infoReverse, change2c).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.2_3insC:p.0?", annotation2c.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation2c.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation2c.varTypes);
 
 		// Insertions between nucleotides 3 and 4.
 
@@ -405,13 +406,13 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 23694495, PositionType.ZERO_BASED), "", "T");
 		Annotation annotation3a = new InsertionAnnotationBuilder(infoReverse, change3a).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.3_4insA:p.Ala2Serfs*16", annotation3a.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3a.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3a.varTypes);
 
 		GenomeChange change3c = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 23694495, PositionType.ZERO_BASED), "", "G");
 		Annotation annotation3c = new InsertionAnnotationBuilder(infoReverse, change3c).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.3_4insC:p.Ala2Argfs*16", annotation3c.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation3c.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation3c.varTypes);
 
 		// Some insertions into stop codon
 
@@ -419,13 +420,13 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 23688463, PositionType.ZERO_BASED), "", "G");
 		Annotation annotation4g = new InsertionAnnotationBuilder(infoReverse, change4g).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1411_1412insC:p.*471Serext*7", annotation4g.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation4g.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation4g.varTypes);
 
 		GenomeChange change4c = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 23688463, PositionType.ZERO_BASED), "", "C");
 		Annotation annotation4c = new InsertionAnnotationBuilder(infoReverse, change4c).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1411_1412insG:p.=", annotation4c.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation4c.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation4c.varTypes);
 	}
 
 	@Test
@@ -439,21 +440,21 @@ public class InsertionAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "", "ACTAGACT");
 		Annotation annotation4actagact = new InsertionAnnotationBuilder(infoReverse, change4actagact).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.4_5insAGTCTAGT:p.Ala2Glufs*16", annotation4actagact.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation4actagact.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation4actagact.varTypes);
 
 		// This insertion will be shifted.
 		GenomeChange change4cgtg = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694494,
 				PositionType.ZERO_BASED), "", "CGTG");
 		Annotation annotation4cgtg = new InsertionAnnotationBuilder(infoReverse, change4cgtg).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.6_7insCGCA:p.Ala3Argfs*16", annotation4cgtg.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation4cgtg.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation4cgtg.varTypes);
 
 		// Insert whole stop codon.
 		GenomeChange change5cgtg = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694492,
 				PositionType.ZERO_BASED), "", "ATTA");
 		Annotation annotation5cgtg = new InsertionAnnotationBuilder(infoReverse, change5cgtg).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.6_7insTAAT:p.Ala3*", annotation5cgtg.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation5cgtg.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation5cgtg.varTypes);
 	}
 
 	@Test
@@ -473,7 +474,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 49218811, PositionType.ZERO_BASED), "", "T");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010slx.2:exon5:c.*255dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	@Test
@@ -493,7 +494,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "AAG");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010vsd.2:exon1:c.-37_-36insCTT", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -513,7 +514,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "GA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc004aus.1:exon3:n.492_493insGA", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -531,7 +532,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 14, 73079293, PositionType.ZERO_BASED), "", "AA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010arh.1:exon1:n.511_512dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	//
@@ -558,7 +559,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 248637422, PositionType.ZERO_BASED), "", "TTC");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001iel.1:exon1:c.769_771dup:p.Phe257dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -595,7 +596,7 @@ public class InsertionAnnotationBuilderTest {
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003izs.3:exon6:c.439dup:p.Met147Asnfs*8", annotation1.hgvsDescription);
 		// TODO(holtgrem): Duplication on nucleotide level but FS insertion for AAs.
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -618,7 +619,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 9, 137968918, PositionType.ZERO_BASED), "", "AGA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010naq.2:exon2:c.325_327dup:p.Arg109dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	@Test
@@ -636,7 +637,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 248637607, PositionType.ZERO_BASED), "", "A");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001iel.1:exon1:c.956dup:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	/**
@@ -662,7 +663,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 248637422, PositionType.ZERO_BASED), "", "CTCTTC");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001iel.1:exon1:c.766_771dup:p.Leu256_Phe257dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -683,7 +684,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 248637422, PositionType.ZERO_BASED), "", "CTGCTGCTCTTC");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001iel.1:exon1:c.760_771dup:p.Leu254_Phe257dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -706,7 +707,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 3, 184429186, PositionType.ZERO_BASED), "", "AGT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003fpa.3:exon1:c.424_426dup:p.Thr142dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -730,7 +731,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 3, 184429171, PositionType.ZERO_BASED), "", "TTTGTT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003fpa.3:exon1:c.439_444dup:p.Asn147_Lys148dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -751,7 +752,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 3, 184429171, PositionType.ZERO_BASED), "", "TTTTAGTTTGTT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003fpa.3:exon1:c.439_450dup:p.Asn147_Lys150dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -777,7 +778,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 248637605, PositionType.ZERO_BASED), "", "GAAAAG");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001iel.1:exon1:c.949_954dup:p.*319Gluext*2", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
 	}
 
 	/**
@@ -806,7 +807,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 3, 184429154, PositionType.ZERO_BASED), "", "TCC");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003fpa.3:exon1:c.474_476dup:p.Glu158dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -831,7 +832,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "ATCG");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002sxk.4:exon7:c.628_629insCGAT:p.Leu210Profs*61", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -854,7 +855,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 109371423, PositionType.ZERO_BASED), "", "CC");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002tem.4:exon16:c.2265_2266insCC:p.Tyr756Profs*21", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -879,7 +880,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 135272376, PositionType.ZERO_BASED), "", "A");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc031sld.1:exon5:c.93_94insA:p.Gln32Thrfs*39", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -902,7 +903,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 109383313, PositionType.ZERO_BASED), "", "AGCG");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002tem.4:exon20:c.6318_6319insAGCG:p.Trp2107Serfs*6", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -927,7 +928,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 109383877, PositionType.ZERO_BASED), "", "CAT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002tem.4:exon20:c.6882_6883insCAT:p.Asp2294_Glu2295insHis", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -950,7 +951,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 179519684, PositionType.ZERO_BASED), "", "AAGT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002umz.1:exon112:c.21594_21595insACTT:p.Val7199Thrfs*8", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -976,7 +977,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 211421454, PositionType.ZERO_BASED), "", "TTC");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010fur.3:exon2:c.15_16insTTC:p.Ile5_Lys6insPhe", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1001,7 +1002,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 3, 195510342, PositionType.ZERO_BASED), "", "CA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc021xjp.1:exon2:c.8108_8109insTG:p.Ser2704Alafs*301", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1024,7 +1025,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 3, 195511592, PositionType.ZERO_BASED), "", "CTG");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc021xjp.1:exon2:c.6858_6859insCAG:p.Thr2286_Thr2287insGln", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1047,7 +1048,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 4, 190881973, PositionType.ZERO_BASED), "", "GACT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003izs.3:exon7:c.608_609insGACT:p.Gln204Thrfs*4", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1070,7 +1071,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "TGA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003jgo.3:exon11:c.1147_1148insTGA:p.Pro383delinsLeuThr", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_SUBSTITUTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_SUBSTITUTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1096,7 +1097,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "T");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003kfl.3:exon8:c.730_731insT:p.Asn244Ilefs*52", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1117,7 +1118,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 140573931, PositionType.ZERO_BASED), "", "ATGC");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003lix.3:exon1:c.1806_1807insATGC:p.Ser603Metfs*144", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1139,7 +1140,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "TTTG");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003nrp.1:exon2:c.255_256insAACA:p.Val86Asnfs*13", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1162,7 +1163,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "TCT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011duf.1:exon8:c.863_864insTCT:p.Leu288dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -1185,7 +1186,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "AAAA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003tkb.4:exon1:c.118_119insAAAA:p.Gly40Glufs*10", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1208,7 +1209,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 7, 100637286, PositionType.ZERO_BASED), "", "GTA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003uxo.3:exon2:c.3442_3443insGTA:p.Ser1147dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	/**
@@ -1231,7 +1232,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 9, 137968919, PositionType.ZERO_BASED), "", "AA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010naq.2:exon2:c.328_329insAA:p.Gly110Glufs*51", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1254,7 +1255,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 37830926, PositionType.ZERO_BASED), "", "G");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002hsk.3:exon3:c.286dup:p.Leu96Profs*16", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.FS_INSERTION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.FS_INSERTION), annotation1.varTypes);
 	}
 
 	/**
@@ -1281,7 +1282,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 4, 190862165, PositionType.ZERO_BASED), "", "C");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003izs.3:exon1:c.1_2insC:p.0?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1.varTypes);
 	}
 
 	/**
@@ -1304,7 +1305,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 4, 190862166, PositionType.ZERO_BASED), "", "A");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003izs.3:exon1:c.2_3insA:p.0?", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), annotation1.varTypes);
 	}
 
 	//
@@ -1331,7 +1332,7 @@ public class InsertionAnnotationBuilderTest {
 				"", "TA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001aod.3:exon5:c.*28_*29insTA", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	/**
@@ -1354,7 +1355,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 192335275, PositionType.ZERO_BASED), "", "TAAT");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001gsh.3:exon5:c.*18_*21dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	/**
@@ -1379,7 +1380,7 @@ public class InsertionAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 4, 190884289, PositionType.ZERO_BASED), "", "GACA");
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003izs.3:exon9:c.*5_*6insGACA", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	// The following variant from the Platinum Genome project caused problems against hg19/ucsc:
@@ -1402,7 +1403,7 @@ public class InsertionAnnotationBuilderTest {
 		Annotation annotation1 = new InsertionAnnotationBuilder(infoForward, change1).build();
 		// The following result is equal to the one of Mutalyzer.
 		Assert.assertEquals("uc011aho.1:exon8:c.660_686dup:p.Ala225_Asp233dup", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.NON_FS_DUPLICATION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.NON_FS_DUPLICATION), annotation1.varTypes);
 	}
 
 	// The following variant from the clinvar project caused problems against hg19/ucsc: chr3:37081782:>TAAG
@@ -1426,7 +1427,7 @@ public class InsertionAnnotationBuilderTest {
 		//
 		// The UCSC transcript DNA sequence is bogus here.
 		Assert.assertEquals("uc010hgj.1:exon4:c.590_591insAAGT:p.Leu197LeuSer*", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation1.varTypes);
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
@@ -135,7 +135,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "T");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1A>T:p.0?", anno.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.START_LOSS), anno.varTypes);
 	}
 
 	@Test
@@ -196,7 +196,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "G");
 		Annotation anno2 = new SNVAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon7:c.1225T>G:p.Cys409Gly", anno2.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), anno2.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION), anno2.varTypes);
 	}
 
 	@Test
@@ -207,19 +207,19 @@ public class SNVAnnotationBuilderTest {
 				"A", "T");
 		Annotation anno1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1A>T:p.0?", anno1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.START_LOSS), anno1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640670, PositionType.ZERO_BASED),
 				"T", "C");
 		Annotation anno2 = new SNVAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.2T>C:p.0?", anno2.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno2.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.START_LOSS), anno2.varTypes);
 
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640671, PositionType.ZERO_BASED),
 				"G", "A");
 		Annotation anno3 = new SNVAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3G>A:p.0?", anno3.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno3.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.START_LOSS), anno3.varTypes);
 
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED),
 				"G", "T");
@@ -337,19 +337,19 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno1 = new SNVAnnotationBuilder(infoReverse, change1).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.1A>T:p.0?", anno1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.START_LOSS), anno1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694496, PositionType.ZERO_BASED),
 				"A", "G");
 		Annotation anno2 = new SNVAnnotationBuilder(infoReverse, change2).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.2T>C:p.0?", anno2.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno2.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.START_LOSS), anno2.varTypes);
 
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694495, PositionType.ZERO_BASED),
 				"C", "T");
 		Annotation anno3 = new SNVAnnotationBuilder(infoReverse, change3).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.3G>A:p.0?", anno3.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno3.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.START_LOSS), anno3.varTypes);
 
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694494, PositionType.ZERO_BASED),
 				"C", "A");
@@ -620,7 +620,8 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011mzv.2:exon12:c.1060A>T:p.Thr354Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -640,7 +641,8 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010nvg.2:exon11:c.1090A>T:p.Thr364Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -660,7 +662,8 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011mzw.2:exon11:c.1099A>T:p.Thr367Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -680,7 +683,8 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc004fmp.2:exon11:c.1150A>T:p.Thr384Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -977,7 +981,8 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bem.2:exon9:c.974C>T:p.Thr325Ile", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -1161,7 +1166,8 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011mzv.2:exon12:c.1060A>T:p.Thr354Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -1966,7 +1972,8 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348071, PositionType.ZERO_BASED), "C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:exon10:c.6332G>C:p.Arg2111Thr", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
@@ -4,11 +4,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSortedSet;
+
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeChange;
 import de.charite.compbio.jannovar.annotation.VariantType;
-import de.charite.compbio.jannovar.annotation.builders.BlockSubstitutionAnnotationBuilder;
-import de.charite.compbio.jannovar.annotation.builders.SNVAnnotationBuilder;
 import de.charite.compbio.jannovar.io.ReferenceDictionary;
 import de.charite.compbio.jannovar.reference.GenomeChange;
 import de.charite.compbio.jannovar.reference.GenomePosition;
@@ -65,7 +65,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("dist=0", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.UPSTREAM, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UPSTREAM), anno.varTypes);
 	}
 
 	@Test
@@ -74,7 +74,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("dist=0", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.DOWNSTREAM, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.DOWNSTREAM), anno.varTypes);
 	}
 
 	@Test
@@ -84,14 +84,14 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=1000", anno1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, anno1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), anno1.varTypes);
 
 		// downstream intergenic
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6650340, PositionType.ZERO_BASED),
 				"T", "A");
 		Annotation anno2 = new SNVAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("dist=1000", anno2.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, anno2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), anno2.varTypes);
 	}
 
 	@Test
@@ -101,14 +101,14 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:c.691-11T>A", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), anno.varTypes);
 
 		// position towards left side of intron
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6646100, PositionType.ZERO_BASED),
 				"T", "A");
 		Annotation anno2 = new SNVAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:c.1044+11T>A", anno2.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, anno2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), anno2.varTypes);
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.*1T>A", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), anno.varTypes);
 	}
 
 	@Test
@@ -126,7 +126,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.-1T>A", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), anno.varTypes);
 	}
 
 	@Test
@@ -135,7 +135,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "T");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1A>T:p.0?", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno.varTypes);
 	}
 
 	@Test
@@ -144,7 +144,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "C");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067G>C:p.*689Tyrext*23", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), anno.varTypes);
 	}
 
 	@Test
@@ -153,7 +153,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2058T>A:p.Cys686*", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), anno.varTypes);
 	}
 
 	@Test
@@ -162,7 +162,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067G>A:p.=", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno.varTypes);
 	}
 
 	@Test
@@ -171,7 +171,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:c.-70+1G>A", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), anno.varTypes);
 	}
 
 	@Test
@@ -180,7 +180,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:c.-69-1G>A", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), anno.varTypes);
 	}
 
 	@Test
@@ -190,13 +190,13 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.-67G>A", anno.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, anno.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), anno.varTypes);
 		// in CDS
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6647537, PositionType.ZERO_BASED),
 				"T", "G");
 		Annotation anno2 = new SNVAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon7:c.1225T>G:p.Cys409Gly", anno2.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, anno2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), anno2.varTypes);
 	}
 
 	@Test
@@ -207,61 +207,61 @@ public class SNVAnnotationBuilderTest {
 				"A", "T");
 		Annotation anno1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.1A>T:p.0?", anno1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, anno1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640670, PositionType.ZERO_BASED),
 				"T", "C");
 		Annotation anno2 = new SNVAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.2T>C:p.0?", anno2.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, anno2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno2.varTypes);
 
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640671, PositionType.ZERO_BASED),
 				"G", "A");
 		Annotation anno3 = new SNVAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.3G>A:p.0?", anno3.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, anno3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno3.varTypes);
 
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640672, PositionType.ZERO_BASED),
 				"G", "T");
 		Annotation anno4 = new SNVAnnotationBuilder(infoForward, change4).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.4G>T:p.Asp2Tyr", anno4.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno4.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno4.varTypes);
 
 		GenomeChange change5 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640673, PositionType.ZERO_BASED),
 				"A", "T");
 		Annotation anno5 = new SNVAnnotationBuilder(infoForward, change5).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.5A>T:p.Asp2Val", anno5.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno5.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno5.varTypes);
 
 		GenomeChange change6 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640674, PositionType.ZERO_BASED),
 				"C", "T");
 		Annotation anno6 = new SNVAnnotationBuilder(infoForward, change6).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.6C>T:p.=", anno6.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno6.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno6.varTypes);
 
 		GenomeChange change7 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640675, PositionType.ZERO_BASED),
 				"G", "T");
 		Annotation anno7 = new SNVAnnotationBuilder(infoForward, change7).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.7G>T:p.Gly3Cys", anno7.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno7.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno7.varTypes);
 
 		GenomeChange change8 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640676, PositionType.ZERO_BASED),
 				"G", "T");
 		Annotation anno8 = new SNVAnnotationBuilder(infoForward, change8).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.8G>T:p.Gly3Val", anno8.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno8.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno8.varTypes);
 
 		GenomeChange change9 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640677, PositionType.ZERO_BASED),
 				"C", "G");
 		Annotation anno9 = new SNVAnnotationBuilder(infoForward, change9).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.9C>G:p.=", anno9.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno9.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno9.varTypes);
 
 		GenomeChange change10 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6640678, PositionType.ZERO_BASED),
 				"T", "A");
 		Annotation anno10 = new SNVAnnotationBuilder(infoForward, change10).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.10T>A:p.Ser4Thr", anno10.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno10.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno10.varTypes);
 	}
 
 	@Test
@@ -272,61 +272,61 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation anno1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2066A>G:p.*689Trpext*23", anno1.hgvsDescription);
-		Assert.assertEquals(anno1.varType, VariantType.STOPLOSS);
+		Assert.assertEquals(anno1.varTypes, ImmutableSortedSet.of(VariantType.STOPLOSS));
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649269, PositionType.ZERO_BASED),
 				"T", "C");
 		Annotation anno2 = new SNVAnnotationBuilder(infoForward, change2).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2065T>C:p.*689Glnext*23", anno2.hgvsDescription);
-		Assert.assertEquals(anno2.varType, VariantType.STOPLOSS);
+		Assert.assertEquals(anno2.varTypes, ImmutableSortedSet.of(VariantType.STOPLOSS));
 
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649268, PositionType.ZERO_BASED),
 				"A", "T");
 		Annotation anno3 = new SNVAnnotationBuilder(infoForward, change3).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2064A>T:p.=", anno3.hgvsDescription);
-		Assert.assertEquals(anno3.varType, VariantType.SYNONYMOUS);
+		Assert.assertEquals(anno3.varTypes, ImmutableSortedSet.of(VariantType.SYNONYMOUS));
 
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649267, PositionType.ZERO_BASED),
 				"C", "G");
 		Annotation anno4 = new SNVAnnotationBuilder(infoForward, change4).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2063C>G:p.Thr688Arg", anno4.hgvsDescription);
-		Assert.assertEquals(anno4.varType, VariantType.MISSENSE);
+		Assert.assertEquals(anno4.varTypes, ImmutableSortedSet.of(VariantType.MISSENSE));
 
 		GenomeChange change5 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649266, PositionType.ZERO_BASED),
 				"A", "G");
 		Annotation anno5 = new SNVAnnotationBuilder(infoForward, change5).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2062A>G:p.Thr688Ala", anno5.hgvsDescription);
-		Assert.assertEquals(anno5.varType, VariantType.MISSENSE);
+		Assert.assertEquals(anno5.varTypes, ImmutableSortedSet.of(VariantType.MISSENSE));
 
 		GenomeChange change6 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649265, PositionType.ZERO_BASED),
 				"C", "T");
 		Annotation anno6 = new SNVAnnotationBuilder(infoForward, change6).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2061C>T:p.=", anno6.hgvsDescription);
-		Assert.assertEquals(anno6.varType, VariantType.SYNONYMOUS);
+		Assert.assertEquals(anno6.varTypes, ImmutableSortedSet.of(VariantType.SYNONYMOUS));
 
 		GenomeChange change7 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649264, PositionType.ZERO_BASED),
 				"A", "G");
 		Annotation anno7 = new SNVAnnotationBuilder(infoForward, change7).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2060A>G:p.Asp687Gly", anno7.hgvsDescription);
-		Assert.assertEquals(anno7.varType, VariantType.MISSENSE);
+		Assert.assertEquals(anno7.varTypes, ImmutableSortedSet.of(VariantType.MISSENSE));
 
 		GenomeChange change8 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649263, PositionType.ZERO_BASED),
 				"G", "A");
 		Annotation anno8 = new SNVAnnotationBuilder(infoForward, change8).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2059G>A:p.Asp687Asn", anno8.hgvsDescription);
-		Assert.assertEquals(anno8.varType, VariantType.MISSENSE);
+		Assert.assertEquals(anno8.varTypes, ImmutableSortedSet.of(VariantType.MISSENSE));
 
 		GenomeChange change9 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649262, PositionType.ZERO_BASED),
 				"T", "G");
 		Annotation anno9 = new SNVAnnotationBuilder(infoForward, change9).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2058T>G:p.Cys686Trp", anno9.hgvsDescription);
-		Assert.assertEquals(anno9.varType, VariantType.MISSENSE);
+		Assert.assertEquals(anno9.varTypes, ImmutableSortedSet.of(VariantType.MISSENSE));
 
 		GenomeChange change10 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6649261, PositionType.ZERO_BASED),
 				"G", "C");
 		Annotation anno10 = new SNVAnnotationBuilder(infoForward, change10).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2057G>C:p.Cys686Ser", anno10.hgvsDescription);
-		Assert.assertEquals(anno10.varType, VariantType.MISSENSE);
+		Assert.assertEquals(anno10.varTypes, ImmutableSortedSet.of(VariantType.MISSENSE));
 	}
 
 	@Test
@@ -337,61 +337,61 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation anno1 = new SNVAnnotationBuilder(infoReverse, change1).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.1A>T:p.0?", anno1.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, anno1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694496, PositionType.ZERO_BASED),
 				"A", "G");
 		Annotation anno2 = new SNVAnnotationBuilder(infoReverse, change2).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.2T>C:p.0?", anno2.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, anno2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno2.varTypes);
 
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694495, PositionType.ZERO_BASED),
 				"C", "T");
 		Annotation anno3 = new SNVAnnotationBuilder(infoReverse, change3).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.3G>A:p.0?", anno3.hgvsDescription);
-		Assert.assertEquals(VariantType.START_LOSS, anno3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.START_LOSS), anno3.varTypes);
 
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694494, PositionType.ZERO_BASED),
 				"C", "A");
 		Annotation anno4 = new SNVAnnotationBuilder(infoReverse, change4).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.4G>T:p.Ala2Ser", anno4.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno4.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno4.varTypes);
 
 		GenomeChange change5 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694493, PositionType.ZERO_BASED),
 				"G", "A");
 		Annotation anno5 = new SNVAnnotationBuilder(infoReverse, change5).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.5C>T:p.Ala2Val", anno5.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno5.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno5.varTypes);
 
 		GenomeChange change6 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694492, PositionType.ZERO_BASED),
 				"T", "G");
 		Annotation anno6 = new SNVAnnotationBuilder(infoReverse, change6).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.6A>C:p.=", anno6.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno6.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno6.varTypes);
 
 		GenomeChange change7 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694491, PositionType.ZERO_BASED),
 				"C", "T");
 		Annotation anno7 = new SNVAnnotationBuilder(infoReverse, change7).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.7G>A:p.Ala3Thr", anno7.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno7.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno7.varTypes);
 
 		GenomeChange change8 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694490, PositionType.ZERO_BASED),
 				"G", "A");
 		Annotation anno8 = new SNVAnnotationBuilder(infoReverse, change8).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.8C>T:p.Ala3Val", anno8.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno8.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno8.varTypes);
 
 		GenomeChange change9 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23694489, PositionType.ZERO_BASED),
 				"G", "C");
 		Annotation anno9 = new SNVAnnotationBuilder(infoReverse, change9).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.9C>G:p.=", anno9.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno9.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno9.varTypes);
 
 		GenomeChange change10 = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 23694488, PositionType.ZERO_BASED), "T", "C");
 		Annotation anno10 = new SNVAnnotationBuilder(infoReverse, change10).build();
 		Assert.assertEquals("uc001bgu.3:exon2:c.10A>G:p.Thr4Ala", anno10.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno10.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno10.varTypes);
 	}
 
 	@Test
@@ -402,61 +402,61 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation anno1 = new SNVAnnotationBuilder(infoReverse, change1).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1413A>G:p.=", anno1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688462, PositionType.ZERO_BASED),
 				"T", "G");
 		Annotation anno2 = new SNVAnnotationBuilder(infoReverse, change2).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1412A>C:p.*471Serext*9", anno2.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, anno2.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), anno2.varTypes);
 
 		GenomeChange change3 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688463, PositionType.ZERO_BASED),
 				"A", "T");
 		Annotation anno3 = new SNVAnnotationBuilder(infoReverse, change3).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1411T>A:p.*471Lysext*9", anno3.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, anno3.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), anno3.varTypes);
 
 		GenomeChange change4 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688464, PositionType.ZERO_BASED),
 				"G", "C");
 		Annotation anno4 = new SNVAnnotationBuilder(infoReverse, change4).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1410C>G:p.Asp470Glu", anno4.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno4.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno4.varTypes);
 
 		GenomeChange change5 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688465, PositionType.ZERO_BASED),
 				"T", "C");
 		Annotation anno5 = new SNVAnnotationBuilder(infoReverse, change5).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1409A>G:p.Asp470Gly", anno5.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno5.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno5.varTypes);
 
 		GenomeChange change6 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688466, PositionType.ZERO_BASED),
 				"C", "A");
 		Annotation anno6 = new SNVAnnotationBuilder(infoReverse, change6).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1408G>T:p.Asp470Tyr", anno6.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno6.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno6.varTypes);
 
 		GenomeChange change7 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688467, PositionType.ZERO_BASED),
 				"C", "G");
 		Annotation anno7 = new SNVAnnotationBuilder(infoReverse, change7).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1407G>C:p.=", anno7.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno7.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno7.varTypes);
 
 		GenomeChange change8 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688468, PositionType.ZERO_BASED),
 				"G", "T");
 		Annotation anno8 = new SNVAnnotationBuilder(infoReverse, change8).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1406C>A:p.Thr469Lys", anno8.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno8.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno8.varTypes);
 
 		GenomeChange change9 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688469, PositionType.ZERO_BASED),
 				"T", "C");
 		Annotation anno9 = new SNVAnnotationBuilder(infoReverse, change9).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1405A>G:p.Thr469Ala", anno9.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, anno9.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), anno9.varTypes);
 
 		GenomeChange change10 = new GenomeChange(
 				new GenomePosition(refDict, '+', 1, 23688470, PositionType.ZERO_BASED), "A", "G");
 		Annotation anno10 = new SNVAnnotationBuilder(infoReverse, change10).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1404T>C:p.=", anno10.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, anno10.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno10.varTypes);
 	}
 
 	//
@@ -478,7 +478,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 212799881, PositionType.ZERO_BASED), "A", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hjk.3:exon1:c.1663A>T:p.Lys555*", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation1.varTypes);
 	}
 
 	@Test
@@ -498,7 +498,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003npv.2:exon5:c.431G>A:p.Trp144*", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation1.varTypes);
 	}
 
 	@Test
@@ -516,7 +516,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 11, 48286230, PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010rht.2:exon1:c.819T>A:p.Tyr273*", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPGAIN, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPGAIN), annotation1.varTypes);
 	}
 
 	@Test
@@ -536,7 +536,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 172180770, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010zdp.2:exon9:c.1000T>C:p.*334Argext*29", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
 	}
 
 	@Test
@@ -556,7 +556,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 172180770, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010zdo.2:c.1134+1T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType); // is also stoploss
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes); // is also stoploss
 	}
 
 	@Test
@@ -576,7 +576,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 172180770, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002ugu.4:exon11:c.1135T>C:p.*379Argext*29", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
 	}
 
 	@Test
@@ -596,7 +596,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003teh.1:exon10:c.1171T>C:p.*391Argext*3", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.STOPLOSS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOPLOSS), annotation1.varTypes);
 	}
 
 	//
@@ -620,7 +620,7 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011mzv.2:exon12:c.1060A>T:p.Thr354Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -640,7 +640,7 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010nvg.2:exon11:c.1090A>T:p.Thr364Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -660,7 +660,7 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011mzw.2:exon11:c.1099A>T:p.Thr367Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -680,7 +680,7 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc004fmp.2:exon11:c.1150A>T:p.Thr384Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -700,7 +700,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 114017028, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010fks.4:exon3:c.166A>G:p.Thr56Ala", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -720,7 +720,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 114017028, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002tjq.5:exon4:c.166A>G:p.Thr56Ala", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -738,7 +738,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 7, 127637815, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003vmj.2:exon1:c.70A>G:p.Thr24Ala", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -758,7 +758,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001amg.3:exon17:c.1718A>G:p.Asn573Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -778,7 +778,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001auk.2:exon3:c.308A>G:p.Glu103Gly", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -797,7 +797,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010obg.2:exon2:c.434A>G:p.His145Arg", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -817,7 +817,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001awf.3:exon2:c.197A>G:p.Glu66Gly", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -837,7 +837,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001awe.1:exon4:c.320A>G:p.Glu107Gly", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -857,7 +857,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010obl.1:exon5:c.515A>G:p.Glu172Gly", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -877,7 +877,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001awd.1:exon6:c.515A>G:p.Glu172Gly", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -897,7 +897,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001awb.2:exon21:c.2756A>G:p.Glu919Gly", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -917,7 +917,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001awp.4:exon5:c.194A>G:p.Gln65Arg", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -937,7 +937,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc021oho.1:exon4:c.229G>A:p.Ala77Thr", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -957,7 +957,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc021ohn.1:exon4:c.47G>A:p.Cys16Tyr", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -977,7 +977,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bem.2:exon9:c.974C>T:p.Thr325Ile", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -997,7 +997,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bfa.3:exon1:c.7G>T:p.Val3Leu", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -1017,7 +1017,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc009vqi.1:exon12:c.2653G>A:p.Val885Met", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -1037,7 +1037,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bie.3:exon5:c.857A>G:p.Gln286Arg", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -1057,7 +1057,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010oez.2:exon2:c.230A>G:p.Gln77Arg", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -1077,7 +1077,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bwx.1:exon1:c.17A>G:p.His6Arg", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -1097,7 +1097,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002rcc.2:exon9:c.727A>G:p.Ile243Val", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -1117,7 +1117,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002rew.3:exon10:c.542G>A:p.Gly181Asp", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	@Test
@@ -1137,7 +1137,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010eyq.2:exon3:c.446A>G:p.Gln149Arg", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 	//
@@ -1161,7 +1161,7 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc011mzv.2:exon12:c.1060A>T:p.Thr354Ser", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -1181,7 +1181,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001aya.2:exon3:c.573G>A:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1201,7 +1201,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bbk.1:exon21:c.2922G>C:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1220,7 +1220,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001bxq.3:exon2:c.-118T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1240,7 +1240,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001cas.2:exon3:c.207C>T:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1260,7 +1260,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 100203692, PositionType.ZERO_BASED), "G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001dsh.1:exon7:c.708C>T:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1280,7 +1280,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 109794251, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001dxa.4:exon1:c.1551T>C:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1300,7 +1300,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 112308971, PositionType.ZERO_BASED), "G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001ebt.3:exon3:c.750G>A:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1320,7 +1320,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 152193290, PositionType.ZERO_BASED), "G", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001ezt.2:exon3:c.814C>A:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1340,7 +1340,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 165533004, PositionType.ZERO_BASED), "C", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001gde.2:exon2:c.886C>A:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1360,7 +1360,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 170501384, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001ggz.4:exon1:c.96C>T:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1380,7 +1380,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 172356436, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001gih.1:exon2:c.291A>G:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1400,7 +1400,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 183105533, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001gpy.4:exon25:c.4128T>C:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1420,7 +1420,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 201969081, PositionType.ZERO_BASED), "G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001gxe.3:exon5:c.246G>A:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1440,7 +1440,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 222721287, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hnh.1:exon1:c.99G>A:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1460,7 +1460,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003str.3:exon7:c.441T>C:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1480,7 +1480,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003suh.3:exon23:c.3030C>T:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1500,7 +1500,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003tta.2:exon4:c.1569T>C:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1520,7 +1520,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010lft.2:exon7:c.936G>A:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1540,7 +1540,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 7, 137128829, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003vtu.3:exon28:c.1785A>G:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1560,7 +1560,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002lzv.4:exon3:c.171T>C:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	@Test
@@ -1580,7 +1580,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 22, 36691606, PositionType.ZERO_BASED), "A", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003apg.3:exon26:c.3429T>G:p.=", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SYNONYMOUS, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), annotation1.varTypes);
 	}
 
 	//
@@ -1604,7 +1604,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003gpr.1:exon37:c.*51G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	@Test
@@ -1624,7 +1624,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 13, 76445188, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001vjy.2:exon1:c.-74A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1644,7 +1644,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 150483839, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010pcf.2:exon6:c.*148C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	@Test
@@ -1664,7 +1664,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 245318687, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001ibf.1:exon1:c.-39C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1684,7 +1684,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 248058878, PositionType.ZERO_BASED), "A", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001idp.1:exon3:c.-10A>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1704,7 +1704,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010yrl.2:exon3:c.-37T>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1723,7 +1723,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 237150165, PositionType.ZERO_BASED), "A", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010fyp.1:exon1:c.-3T>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1743,7 +1743,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 6, 108093579, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010kdf.3:exon2:c.-49G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1763,7 +1763,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003ztp.2:exon1:c.-393T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1783,7 +1783,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 9, 114521629, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010mug.4:exon1:c.-62T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1803,7 +1803,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 61565989, PositionType.ZERO_BASED), "G", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010ddv.2:exon5:c.-33G>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1823,7 +1823,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 22, 26862152, PositionType.ZERO_BASED), "C", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003ach.4:exon5:c.-725G>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	@Test
@@ -1843,7 +1843,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001dcv.3:c.336+1G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1863,7 +1863,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001alq.2:c.2818-2T>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1882,7 +1882,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001byw.3:c.225-1G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1902,7 +1902,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348180, PositionType.ZERO_BASED), "C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6224-1G>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1922,7 +1922,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348069, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6332+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1942,7 +1942,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348068, PositionType.ZERO_BASED), "T", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6332+3A>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -1962,7 +1962,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348071, PositionType.ZERO_BASED), "C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:exon10:c.6332G>C:p.Arg2111Thr", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -1982,7 +1982,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348067, PositionType.ZERO_BASED), "GTA", "AGG");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6332+2_6332+4delinsCCT", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2002,7 +2002,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 156704286, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fpu.3:c.1121+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2022,7 +2022,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 158064181, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fro.4:c.1239+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2042,7 +2042,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 212964869, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hjn.3:c.234+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2062,7 +2062,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 247419508, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010pyu.2:c.135+1T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2082,7 +2082,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002rso.1:c.214-2A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2102,7 +2102,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010ysm.2:c.1074-1G>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2122,7 +2122,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002spq.3:c.168+2T>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_DONOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2142,7 +2142,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 110926130, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002tfo.4:c.337-1G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_ACCEPTOR, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2162,7 +2162,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc003gpr.1:exon37:c.*51G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	//
@@ -2186,7 +2186,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48883011, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc009zky.1:exon5:n.359T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2205,7 +2205,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 173429994, PositionType.ZERO_BASED), "G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010pmp.1:exon1:n.507C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2223,7 +2223,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 5, 159912417, PositionType.ZERO_BASED), "C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc021yhe.1:exon1:n.60C>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2243,7 +2243,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 36353760, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010wdn.1:exon9:n.876G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2263,7 +2263,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 18, 19408949, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002kts.3:exon3:n.724G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2283,7 +2283,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 20, 25829351, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002wve.3:exon2:n.375A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2301,7 +2301,7 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc004dzz.3:exon1:n.647A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2321,7 +2321,7 @@ public class SNVAnnotationBuilderTest {
 				PositionType.ZERO_BASED), "C", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc004frk.2:exon3:n.250G>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_EXONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_EXONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2346,7 +2346,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 219128505, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010zjy.1:exon2:c.*66C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	//
@@ -2370,7 +2370,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=39337", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), annotation1.varTypes);
 	}
 
 	@Test
@@ -2390,7 +2390,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 132349413, PositionType.ZERO_BASED), "G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=58174", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2413,7 +2413,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("dist=42221", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTERGENIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTERGENIC), annotation1.varTypes);
 	}
 
 	// Various Intronic Variants
@@ -2439,7 +2439,7 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001acf.3:c.1597+24A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2465,7 +2465,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48876499, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rrr.3:c.-58+141C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	/**
@@ -2491,7 +2491,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48876999, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rrr.3:c.-57-23C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	/**
@@ -2518,7 +2518,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48888799, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rrr.3:c.*40+38C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	/**
@@ -2544,7 +2544,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48889799, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rrr.3:c.*41-164T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	/**
@@ -2570,7 +2570,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48880599, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rrr.3:c.135+91T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2596,7 +2596,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48882699, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rrr.3:c.136-7C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	/**
@@ -2620,7 +2620,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 222761999, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hni.2:c.-174-93T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	/**
@@ -2644,7 +2644,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 222762999, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hni.2:c.-175+69A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR5, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5), annotation1.varTypes);
 	}
 
 	/**
@@ -2670,7 +2670,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 222731699, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc009xdy.1:c.*38-90T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	/**
@@ -2696,7 +2696,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 222731899, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc009xdy.1:c.*37+65A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.UTR3, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR3), annotation1.varTypes);
 	}
 
 	/**
@@ -2720,7 +2720,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 222736699, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hni.2:c.620-62T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2744,7 +2744,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 222737199, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hni.2:c.619+201T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2770,7 +2770,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 20, 25943999, PositionType.ZERO_BASED), "C", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002wvf.3:n.313+168C>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2796,7 +2796,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 20, 25944999, PositionType.ZERO_BASED), "C", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002wvf.3:n.314-639C>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2822,7 +2822,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 36360999, PositionType.ZERO_BASED), "A", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010wdn.1:n.424+697T>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2848,7 +2848,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 17, 36359599, PositionType.ZERO_BASED), "G", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010wdn.1:n.425-558C>A", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.ncRNA_INTRONIC, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.ncRNA_INTRONIC), annotation1.varTypes);
 	}
 
 	/**
@@ -2873,7 +2873,7 @@ public class SNVAnnotationBuilderTest {
 				"C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001amb.2:c.1803-7G>C", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.SPLICE_REGION, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
 	}
 
 	@Test
@@ -2893,7 +2893,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 156107469, PositionType.ZERO_BASED), "G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010pha.1:exon5:c.602G>A:p.Arg201His", annotation1.hgvsDescription);
-		Assert.assertEquals(VariantType.MISSENSE, annotation1.varType);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.MISSENSE), annotation1.varTypes);
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
@@ -171,7 +171,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:c.-70+1G>A", anno.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), anno.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5, VariantType.SPLICE_DONOR), anno.varTypes);
 	}
 
 	@Test
@@ -180,7 +180,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:c.-69-1G>A", anno.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), anno.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5, VariantType.SPLICE_ACCEPTOR), anno.varTypes);
 	}
 
 	@Test
@@ -190,7 +190,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon2:c.-67G>A", anno.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), anno.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.UTR5, VariantType.SPLICE_REGION), anno.varTypes);
 		// in CDS
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 6647537, PositionType.ZERO_BASED),
 				"T", "G");
@@ -556,7 +556,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 172180770, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010zdo.2:c.1134+1T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes); // is also stoploss
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1843,7 +1843,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001dcv.3:c.336+1G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1863,7 +1863,8 @@ public class SNVAnnotationBuilderTest {
 				"A", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001alq.2:c.2818-2T>A", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -1882,7 +1883,8 @@ public class SNVAnnotationBuilderTest {
 				"C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001byw.3:c.225-1G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -1902,7 +1904,8 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348180, PositionType.ZERO_BASED), "C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6224-1G>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -1922,7 +1925,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348069, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6332+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -1942,7 +1945,8 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348068, PositionType.ZERO_BASED), "T", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6332+3A>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -1982,7 +1986,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 155348067, PositionType.ZERO_BASED), "GTA", "AGG");
 		Annotation annotation1 = new BlockSubstitutionAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fkt.3:c.6332+2_6332+4delinsCCT", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2002,7 +2006,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 156704286, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fpu.3:c.1121+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2022,7 +2026,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 158064181, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001fro.4:c.1239+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2042,7 +2046,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 212964869, PositionType.ZERO_BASED), "A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001hjn.3:c.234+2T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2062,7 +2066,7 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 1, 247419508, PositionType.ZERO_BASED), "T", "C");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010pyu.2:c.135+1T>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2082,7 +2086,8 @@ public class SNVAnnotationBuilderTest {
 				"A", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002rso.1:c.214-2A>G", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -2102,7 +2107,8 @@ public class SNVAnnotationBuilderTest {
 				"C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc010ysm.2:c.1074-1G>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -2122,7 +2128,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "A");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002spq.3:c.168+2T>A", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_DONOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_DONOR), annotation1.varTypes);
 	}
 
 	@Test
@@ -2142,7 +2148,8 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 2, 110926130, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc002tfo.4:c.337-1G>A", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_ACCEPTOR), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_ACCEPTOR),
+				annotation1.varTypes);
 	}
 
 	@Test
@@ -2596,7 +2603,8 @@ public class SNVAnnotationBuilderTest {
 				new GenomePosition(refDict, '+', 12, 48882699, PositionType.ZERO_BASED), "C", "T");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001rrr.3:c.136-7C>T", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	/**
@@ -2873,7 +2881,8 @@ public class SNVAnnotationBuilderTest {
 				"C", "G");
 		Annotation annotation1 = new SNVAnnotationBuilder(infoForward, change1).build();
 		Assert.assertEquals("uc001amb.2:c.1803-7G>C", annotation1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SPLICE_REGION), annotation1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.INTRONIC, VariantType.SPLICE_REGION),
+				annotation1.varTypes);
 	}
 
 	@Test

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
@@ -162,7 +162,7 @@ public class SNVAnnotationBuilderTest {
 				"G", "A");
 		Annotation anno = new SNVAnnotationBuilder(infoForward, change).build();
 		Assert.assertEquals("uc001anx.3:exon11:c.2067G>A:p.=", anno.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOP_RETAINED, VariantType.SYNONYMOUS), anno.varTypes);
 	}
 
 	@Test
@@ -402,7 +402,7 @@ public class SNVAnnotationBuilderTest {
 				"T", "C");
 		Annotation anno1 = new SNVAnnotationBuilder(infoReverse, change1).build();
 		Assert.assertEquals("uc001bgu.3:exon4:c.1413A>G:p.=", anno1.hgvsDescription);
-		Assert.assertEquals(ImmutableSortedSet.of(VariantType.SYNONYMOUS), anno1.varTypes);
+		Assert.assertEquals(ImmutableSortedSet.of(VariantType.STOP_RETAINED, VariantType.SYNONYMOUS), anno1.varTypes);
 
 		GenomeChange change2 = new GenomeChange(new GenomePosition(refDict, '+', 1, 23688462, PositionType.ZERO_BASED),
 				"T", "G");

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/common/VariantTypeTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/common/VariantTypeTest.java
@@ -15,14 +15,7 @@ public class VariantTypeTest {
 	@Test
 	public void testNumberOfConstants() {
 		int n = VariantType.class.getEnumConstants().length;
-		Assert.assertEquals(33, n);
-	}
-
-	@Test
-	public void testAllConstantsAreInPriorityList() {
-		int n = VariantType.getPrioritySortedList().length;
-		int m = VariantType.class.getEnumConstants().length;
-		Assert.assertEquals(n, m);
+		Assert.assertEquals(34, n);
 	}
 
 	@Test
@@ -195,18 +188,6 @@ public class VariantTypeTest {
 		Assert.assertEquals(1, n);
 	}
 
-	/*
-	 * This tests that the constants returned by the function getPrioritySortedList() are arranged in monotonically
-	 * non-decreasing order.
-	 */
-	@Test
-	public void testOrderingOfPriorityLevel() {
-		VariantType n[] = VariantType.getPrioritySortedList();
-		for (int i = 1; i < n.length; ++i) {
-			Assert.assertTrue(n[i - 1].priorityLevel() <= n[i].priorityLevel());
-		}
-	}
-
 	@Test
 	public void testFSDeletionString() {
 		String s = VariantType.FS_DELETION.toDisplayString();
@@ -233,7 +214,7 @@ public class VariantTypeTest {
 
 	@Test
 	public void testSize() {
-		Assert.assertEquals(33, VariantType.size());
+		Assert.assertEquals(34, VariantType.size);
 	}
 
 	@Test

--- a/jannovar-core/src/test/resources/log4j2.xml
+++ b/jannovar-core/src/test/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+	<Appenders>
+		<Console name="CONSOLE" target="SYSTEM_OUT">
+			<PatternLayout pattern="%d %-5p %c{8} [%t] - %m%n" />
+		</Console>
+		<!-- Async Appender should be configured after the appenders it references.
+			This will allow it to shutdown properly. -->
+		<Async name="ASYNC">
+			<AppenderRef ref="CONSOLE" />
+		</Async>
+	</Appenders>
+	<Loggers>
+		<Root level="info">
+			<AppenderRef ref="ASYNC" />
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
This will fix #63.

However, this only adds support for more than one annotation. Updating the builders is still to be done and should be done before merging.