### PR TITLE
AnnotationList must now be constructed with a GenomeChange.

### DIFF
--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotatedVCFWriter.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotatedVCFWriter.java
@@ -13,8 +13,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import de.charite.compbio.jannovar.JannovarOptions;
-import de.charite.compbio.jannovar.annotation.AnnotationException;
 import de.charite.compbio.jannovar.htsjdk.InfoFields;
+import de.charite.compbio.jannovar.htsjdk.InvalidCoordinatesException;
 import de.charite.compbio.jannovar.htsjdk.VariantContextAnnotator;
 import de.charite.compbio.jannovar.htsjdk.VariantContextWriterConstructionHelper;
 import de.charite.compbio.jannovar.impl.util.PathUtil;
@@ -82,9 +82,13 @@ public class AnnotatedVCFWriter extends AnnotatedVariantWriter {
 	}
 
 	@Override
-	public void put(VariantContext vc) throws AnnotationException {
-		vc = annotator.applyAnnotations(vc, annotator.buildAnnotationList(vc));
-		vc.getCommonInfo().removeAttribute("");
+	public void put(VariantContext vc) {
+		try {
+			vc = annotator.applyAnnotations(vc, annotator.buildAnnotationList(vc));
+		} catch (InvalidCoordinatesException e) {
+			annotator.putErrorAnnotation(vc, ImmutableSet.of(e.getAnnotationMessage()));
+		}
+		vc.getCommonInfo().removeAttribute(""); // remove leading/trailing comma
 		out.add(vc);
 	}
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationCollector.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationCollector.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 
+import de.charite.compbio.jannovar.reference.GenomeChange;
+
 /**
  * This class collects all the information about a variant and its annotations and calculates the final annotations for
  * a given variant. The {@link de.charite.compbio.jannovar.io.Chromosome Chromosome} objects each use an instance of
@@ -61,6 +63,9 @@ final class AnnotationCollector {
 
 	/** the logger object to use */
 	private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationCollector.class);
+
+	/** The genomic change to collect annotations for. */
+	private GenomeChange change;
 
 	/** List of all {@link Annotation} objects found for exonic variation. */
 	private ArrayList<Annotation> annotationLst = null;
@@ -126,6 +131,7 @@ final class AnnotationCollector {
 	public AnnotationCollector(int initialCapacity) {
 		this.annotationLst = new ArrayList<Annotation>();
 		this.geneSymbolSet = new HashSet<String>();
+		this.change = change;
 	}
 
 	/**
@@ -194,10 +200,12 @@ final class AnnotationCollector {
 	 * are the best candidates. Otherwise, return all variants that affect other exonic sequences (UTRs, ncRNA).
 	 * Otherwise, return UPSTREAM and DOWNSTREAM annotations if they exist. Otherwise, return an intergenic Annotation.
 	 *
+	 * @param change
+	 *            <code>GenomeChange</code> to build the <code>AnnotationList</code> for
 	 * @return returns the {@link AnnotationList} with all associated {@link Annotation}s
 	 */
-	public AnnotationList getAnnotationList() {
-		return new AnnotationList(this.annotationLst);
+	public AnnotationList getAnnotationList(GenomeChange change) {
+		return new AnnotationList(change, this.annotationLst);
 	}
 
 	/**

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationList.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationList.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMultiset;
 
 import de.charite.compbio.jannovar.Immutable;
+import de.charite.compbio.jannovar.reference.GenomeChange;
 
 /**
  * A list of priority-sorted {@link Annotation} objects.
@@ -21,20 +22,39 @@ import de.charite.compbio.jannovar.Immutable;
 @Immutable
 public final class AnnotationList implements List<Annotation> {
 
-	/** empty annotation list */
-	public static final AnnotationList EMPTY = new AnnotationList(ImmutableList.<Annotation> of());
+	/** the {@link GenomeChange} that this <code>AnnotationList</code> contains entries for. */
+	private final GenomeChange change;
 
 	/** the list of the annotations */
 	private final ImmutableList<Annotation> entries;
 
 	/**
+	 * @param change
+	 *            to use for the empty list
+	 * @return empty <code>AnnotationList</code> with the given {@link GenomeChange}
+	 */
+	public static AnnotationList buildEmptyList(GenomeChange change) {
+		return new AnnotationList(change, ImmutableList.<Annotation> of());
+	}
+
+	/**
 	 * Construct ImmutableAnnotationList from a {@link Collection} of {@link Annotation} objects.
 	 *
+	 * @param change
+	 *            {@link GenomeChange} that this anotation list annotates
 	 * @param entries
 	 *            {@link Collection} of {@link Annotation} objects
 	 */
-	public AnnotationList(Collection<Annotation> entries) {
+	public AnnotationList(GenomeChange change, Collection<Annotation> entries) {
+		this.change = change;
 		this.entries = ImmutableList.copyOf(ImmutableSortedMultiset.copyOf(entries));
+	}
+
+	/**
+	 * @return {@link GenomeChange} that this <code>AnnotationList</code> contains entries for.
+	 */
+	public GenomeChange getChange() {
+		return change;
 	}
 
 	/**
@@ -63,7 +83,7 @@ public final class AnnotationList implements List<Annotation> {
 
 	@Override
 	public String toString() {
-		return "[" + entries + "]";
+		return "AnnotationList(change=" + change + ", entries=[" + entries + "])";
 	}
 
 	@Override
@@ -213,7 +233,7 @@ public final class AnnotationList implements List<Annotation> {
 
 	@Override
 	public AnnotationList subList(int fromIndex, int toIndex) {
-		return new AnnotationList(entries.subList(fromIndex, toIndex));
+		return new AnnotationList(change, entries.subList(fromIndex, toIndex));
 	}
 
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/BestAnnotationListTextGenerator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/BestAnnotationListTextGenerator.java
@@ -18,8 +18,8 @@ public final class BestAnnotationListTextGenerator extends AnnotationListTextGen
 	@Override
 	protected AnnotationList getAnnotations() {
 		if (annotations.isEmpty())
-			return new AnnotationList(annotations.subList(0, 0));
+			return new AnnotationList(annotations.getChange(), annotations.subList(0, 0));
 		else
-			return new AnnotationList(annotations.subList(0, 1));
+			return new AnnotationList(annotations.getChange(), annotations.subList(0, 1));
 	}
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotator.java
@@ -115,7 +115,7 @@ public final class VariantAnnotator {
 		// Short-circuit in the case of symbolic changes/alleles. These could be SVs, large duplications, etc., that are
 		// described as shortcuts in the VCF file. We cannot annotate these yet.
 		if (change.isSymbolic())
-			return AnnotationList.EMPTY;
+			return AnnotationList.buildEmptyList(change);
 
 		// Get genomic change interval and reset the factory.
 		final GenomeInterval changeInterval = change.getGenomeInterval();
@@ -138,7 +138,7 @@ public final class VariantAnnotator {
 				buildSVAnnotation(change, null);
 			else
 				buildNonSVAnnotation(change, qr.left, qr.right);
-			return annovarFactory.getAnnotationList();
+			return annovarFactory.getAnnotationList(change);
 		}
 
 		// If we reach here, then there is at least one transcript that overlaps with the query. Iterate over these
@@ -149,7 +149,7 @@ public final class VariantAnnotator {
 			else
 				buildNonSVAnnotation(change, tm);
 
-		return annovarFactory.getAnnotationList();
+		return annovarFactory.getAnnotationList(change);
 	}
 
 	private void buildSVAnnotation(GenomeChange change, TranscriptModel transcript) throws AnnotationException {

--- a/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/InvalidCoordinatesException.java
+++ b/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/InvalidCoordinatesException.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.htsjdk;
 
+import de.charite.compbio.jannovar.annotation.AnnotationMessage;
+
 /**
  * Thrown in {@link VariantContextAnnotator} in the case of invalid positions (unknown chromsomes).
  *
@@ -7,16 +9,25 @@ package de.charite.compbio.jannovar.htsjdk;
  */
 public class InvalidCoordinatesException extends Exception {
 
-	public InvalidCoordinatesException() {
+	final private AnnotationMessage annotationMessage;
+
+	public InvalidCoordinatesException(AnnotationMessage annotationMessage) {
 		super();
+		this.annotationMessage = annotationMessage;
 	}
 
-	public InvalidCoordinatesException(String msg) {
+	public InvalidCoordinatesException(String msg, AnnotationMessage annotationMessage) {
 		super(msg);
+		this.annotationMessage = annotationMessage;
 	}
 
-	public InvalidCoordinatesException(String msg, Throwable other) {
+	public InvalidCoordinatesException(String msg, Throwable other, AnnotationMessage annotationMessage) {
 		super(msg, other);
+		this.annotationMessage = annotationMessage;
+	}
+
+	public AnnotationMessage getAnnotationMessage() {
+		return annotationMessage;
 	}
 
 	private static final long serialVersionUID = 1L;


### PR DESCRIPTION
This gives the guarantee that the GenomeChange inside an AnnotationList
is never `null`.