### PR TITLE
null pointer fix if no gene is available!

### DIFF
--- a/jannovar-filter/src/main/java/de/charite/compbio/jannovar/filter/GeneWiseInheritanceFilter.java
+++ b/jannovar-filter/src/main/java/de/charite/compbio/jannovar/filter/GeneWiseInheritanceFilter.java
@@ -116,6 +116,8 @@ public class GeneWiseInheritanceFilter implements VariantContextFilter {
 			return;
 		final int contigID = refDict.getContigNameToID().get(vc.getVC().getChr());
 		IntervalArray<Gene> iTree = geneList.getGeneIntervalTree().get(contigID);
+		if (iTree == null)
+			return;
 
 		// consider each alternative allele of the variant
 		for (int alleleID = 0; alleleID < vc.getVC().getAlternateAlleles().size(); ++alleleID) {


### PR DESCRIPTION
this should be fixed in every version. iTree can be null... :-(

Or use a more sophisticated approach