### PR TITLE
Library updates

### DIFF
--- a/jannovar-cli/pom.xml
+++ b/jannovar-cli/pom.xml
@@ -26,12 +26,6 @@
 			<version>1.3.1</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
 			<version>1.143</version>
@@ -39,7 +33,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ini4j</groupId>

--- a/jannovar-cli/pom.xml
+++ b/jannovar-cli/pom.xml
@@ -58,20 +58,15 @@
 		</dependency>
 		<!-- Logging -->
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
 	</dependencies>
 
 	<build>

--- a/jannovar-cli/pom.xml
+++ b/jannovar-cli/pom.xml
@@ -29,6 +29,12 @@
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
 			<version>1.143</version>
+			<exclusions>
+				<exclusion>
+        	<groupId>org.tukaani</groupId>
+          <artifactId>xz</artifactId>
+        </exclusion>
+	    </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/jannovar-cli/pom.xml
+++ b/jannovar-cli/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
-			<version>1.138</version>
+			<version>1.143</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/jannovar-cli/pom.xml
+++ b/jannovar-cli/pom.xml
@@ -56,12 +56,6 @@
 			<artifactId>jannovar-htsjdk</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!--Logging framework -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
-		</dependency>
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/jannovar-core/pom.xml
+++ b/jannovar-core/pom.xml
@@ -52,24 +52,7 @@
 			<artifactId>ini4j</artifactId>
 			<version>0.5.1</version>
 		</dependency>
-		<!-- Logging -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<!-- Logging implementation for test only. -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
-			<scope>test</scope>
-		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/jannovar-core/pom.xml
+++ b/jannovar-core/pom.xml
@@ -52,12 +52,6 @@
 			<artifactId>ini4j</artifactId>
 			<version>0.5.1</version>
 		</dependency>
-		<!--Logging framework -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
-		</dependency>
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/jannovar-core/pom.xml
+++ b/jannovar-core/pom.xml
@@ -30,15 +30,9 @@
 			<version>3.3</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>19.0</version>
 		</dependency>
 		<!-- HGVS variant description -->
 		<dependency>

--- a/jannovar-filter/pom.xml
+++ b/jannovar-filter/pom.xml
@@ -45,12 +45,6 @@
 			<artifactId>jannovar-inheritance-checker</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!--Logging framework -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
-		</dependency>
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/jannovar-filter/pom.xml
+++ b/jannovar-filter/pom.xml
@@ -24,6 +24,12 @@
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
 			<version>1.143</version>
+			<exclusions>
+				<exclusion>
+        	<groupId>org.tukaani</groupId>
+          <artifactId>xz</artifactId>
+        </exclusion>
+	    </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/jannovar-filter/pom.xml
+++ b/jannovar-filter/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ini4j</groupId>

--- a/jannovar-filter/pom.xml
+++ b/jannovar-filter/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
-			<version>1.138</version>
+			<version>1.143</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/jannovar-filter/pom.xml
+++ b/jannovar-filter/pom.xml
@@ -45,27 +45,6 @@
 			<artifactId>jannovar-inheritance-checker</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!-- Logging -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/jannovar-hgvs/pom.xml
+++ b/jannovar-hgvs/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4-runtime</artifactId>
-			<version>4.3</version>
+			<version>4.5.1-1</version>
 		</dependency>
 	</dependencies>
 
@@ -74,7 +74,7 @@
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>
-				<version>4.3</version>
+				<version>4.5.1-1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/jannovar-hgvs/pom.xml
+++ b/jannovar-hgvs/pom.xml
@@ -38,24 +38,6 @@
 			<artifactId>antlr4-runtime</artifactId>
 			<version>4.3</version>
 		</dependency>
-		<!-- Logging -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<!-- Logging implementation for test only. -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/jannovar-hgvs/pom.xml
+++ b/jannovar-hgvs/pom.xml
@@ -22,15 +22,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>19.0</version>
 		</dependency>
 		<!-- Antlr4 runtime -->
 		<dependency>

--- a/jannovar-hgvs/pom.xml
+++ b/jannovar-hgvs/pom.xml
@@ -38,12 +38,6 @@
 			<artifactId>antlr4-runtime</artifactId>
 			<version>4.3</version>
 		</dependency>
-		<!-- Logging framework -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
-		</dependency>
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/jannovar-htsjdk/pom.xml
+++ b/jannovar-htsjdk/pom.xml
@@ -55,12 +55,6 @@
 			<artifactId>jannovar-hgvs</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!--Logging framework -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
-		</dependency>
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/jannovar-htsjdk/pom.xml
+++ b/jannovar-htsjdk/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
-			<version>1.138</version>
+			<version>1.143</version>
 		</dependency>
 		<dependency>
 			<groupId>de.charite.compbio</groupId>

--- a/jannovar-htsjdk/pom.xml
+++ b/jannovar-htsjdk/pom.xml
@@ -30,15 +30,9 @@
 			<version>3.3</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.samtools</groupId>

--- a/jannovar-htsjdk/pom.xml
+++ b/jannovar-htsjdk/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>de.charite.compbio</groupId>
 		<artifactId>Jannovar</artifactId>
-                <version>0.16-SNAPSHOT</version>
+    <version>0.16-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/jannovar-htsjdk/pom.xml
+++ b/jannovar-htsjdk/pom.xml
@@ -38,6 +38,12 @@
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
 			<version>1.143</version>
+			<exclusions>
+				<exclusion>
+        	<groupId>org.tukaani</groupId>
+          <artifactId>xz</artifactId>
+        </exclusion>
+	    </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>de.charite.compbio</groupId>

--- a/jannovar-htsjdk/pom.xml
+++ b/jannovar-htsjdk/pom.xml
@@ -55,24 +55,6 @@
 			<artifactId>jannovar-hgvs</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!-- Logging -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<!-- Logging implementation for test only. -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/jannovar-inheritance-checker/pom.xml
+++ b/jannovar-inheritance-checker/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
-			<version>1.138</version>
+			<version>1.143</version>
 		</dependency>
 	</dependencies>
 

--- a/jannovar-inheritance-checker/pom.xml
+++ b/jannovar-inheritance-checker/pom.xml
@@ -28,6 +28,12 @@
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
 			<version>1.143</version>
+			<exclusions>
+				<exclusion>
+        	<groupId>org.tukaani</groupId>
+          <artifactId>xz</artifactId>
+        </exclusion>
+	    </exclusions>
 		</dependency>
 	</dependencies>
 

--- a/jannovar-inheritance-checker/pom.xml
+++ b/jannovar-inheritance-checker/pom.xml
@@ -29,12 +29,6 @@
 			<artifactId>htsjdk</artifactId>
 			<version>1.138</version>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/jped-cli/pom.xml
+++ b/jped-cli/pom.xml
@@ -69,20 +69,15 @@
 		</dependency>
 		<!-- Logging -->
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
 	</dependencies>
 
 	<build>

--- a/jped-cli/pom.xml
+++ b/jped-cli/pom.xml
@@ -30,6 +30,12 @@
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
 			<version>1.143</version>
+			<exclusions>
+				<exclusion>
+        	<groupId>org.tukaani</groupId>
+          <artifactId>xz</artifactId>
+        </exclusion>
+	    </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/jped-cli/pom.xml
+++ b/jped-cli/pom.xml
@@ -67,12 +67,6 @@
 			<artifactId>jannovar-filter</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!--Logging framework -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
-		</dependency>
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/jped-cli/pom.xml
+++ b/jped-cli/pom.xml
@@ -27,20 +27,14 @@
 			<version>1.3.1</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
-			<version>1.128</version>
+			<version>1.143</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ini4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.13</version>
+			<version>1.7.12</version>
 		</dependency>
 		<!-- Logging implementation for test only. -->
 		<dependency>
@@ -121,6 +121,25 @@
 						<user.region>GB</user.region>
 					</systemPropertyVariables>
 				</configuration>
+			</plugin>
+
+			<plugin>
+    		<groupId>org.apache.maven.plugins</groupId>
+   		 	<artifactId>maven-enforcer-plugin</artifactId>
+   	 		<version>1.4.1</version>
+   		 	<executions>
+      		<execution>
+        		<id>enforce</id>
+        		<configuration>
+        	  	<rules>
+        	    	<DependencyConvergence/>
+        	  	</rules>
+        		</configuration>
+        		<goals>
+        	  	<goal>enforce</goal>
+        		</goals>
+      		</execution>
+    		</executions>
 			</plugin>
 
 			<!-- Javadoc generation. -->

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.7</version>
+			<version>1.7.13</version>
 		</dependency>
 		<!-- Logging -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<log4j.version>2.1</log4j.version>
+		<log4j.version>2.5</log4j.version>
 	</properties>
 
 	<dependencies>
@@ -82,16 +82,25 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.13</version>
 		</dependency>
-		<!-- Logging -->
+		<!-- Logging implementation for test only. -->
+		<dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j.version}</version>
+				<scope>test</scope>
+      </dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
+			<artifactId>log4j-slf4j-impl</artifactId>
 			<version>${log4j.version}</version>
+			<scope>test</scope>
 		</dependency>
+		<!-- JUnit testing -->
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- I removed unnecessary libraries in module poms.

- I update several libraries including guava, htsjdk (to latest 1.X version), slfj-api, antlr,...

- log4j is now used only in tests and in the clis modules.

- Include the maven enforcer update to find problems with different included versions of libraries.