### PR TITLE
Hotfix/chr names in vc fs

### DIFF
--- a/jannovar-filter/src/main/java/de/charite/compbio/jannovar/filter/GeneWiseInheritanceFilter.java
+++ b/jannovar-filter/src/main/java/de/charite/compbio/jannovar/filter/GeneWiseInheritanceFilter.java
@@ -72,6 +72,7 @@ public class GeneWiseInheritanceFilter implements VariantContextFilter {
 		List<String> contigs = new ArrayList<String>();
 		for (Chromosome chr : jannovarDB.getChromosomes().values()) {
 			contigs.add(chr.getChromosomeName());
+			contigs.add("chr"+chr.getChromosomeName());
 		}
 		this.passedVariants = Sets.newTreeSet(new VariantContextComparator(contigs));
 	}

--- a/jannovar-filter/src/test/java/de/charite/compbio/jannovar/filter/GeneWiseInheritanceFilterCHRTest.java
+++ b/jannovar-filter/src/test/java/de/charite/compbio/jannovar/filter/GeneWiseInheritanceFilterCHRTest.java
@@ -1,0 +1,171 @@
+package de.charite.compbio.jannovar.filter;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import de.charite.compbio.jannovar.data.JannovarData;
+import de.charite.compbio.jannovar.factories.TestJannovarDataFactory;
+import de.charite.compbio.jannovar.pedigree.Disease;
+import de.charite.compbio.jannovar.pedigree.ModeOfInheritance;
+import de.charite.compbio.jannovar.pedigree.PedFileContents;
+import de.charite.compbio.jannovar.pedigree.PedParseException;
+import de.charite.compbio.jannovar.pedigree.PedPerson;
+import de.charite.compbio.jannovar.pedigree.Pedigree;
+import de.charite.compbio.jannovar.pedigree.Sex;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFFileReader;
+
+public class GeneWiseInheritanceFilterCHRTest {
+	private Pedigree pedigreeAffectedChild;
+	private Pedigree pedigreeAffectedTwoAffected;
+	private JannovarData jannovarDB;
+	private List<VariantContext> variants;
+	final Path inheritanceFilterVCFPath = Paths.get("src/test/resources/inheritanceFilterCHRTest.vcf");
+	private VCFFileReader reader;
+
+	@Before
+	public void setUp() throws PedParseException {
+		ImmutableList.Builder<PedPerson> individuals = new ImmutableList.Builder<PedPerson>();
+		individuals.add(new PedPerson("ped", "Eva", "0", "0", Sex.FEMALE, Disease.UNAFFECTED)); // Mother
+		individuals.add(new PedPerson("ped", "Adam", "0", "0", Sex.MALE, Disease.UNAFFECTED)); // Father
+		individuals.add(new PedPerson("ped", "Seth", "Adam", "Eva", Sex.MALE, Disease.AFFECTED)); // Child
+		PedFileContents pedFileContents = new PedFileContents(new ImmutableList.Builder<String>().build(),
+				individuals.build());
+		pedigreeAffectedChild = new Pedigree(pedFileContents, "ped");
+
+		individuals = new ImmutableList.Builder<PedPerson>();
+		individuals.add(new PedPerson("ped", "Eva", "0", "0", Sex.FEMALE, Disease.UNAFFECTED)); // Mother
+		individuals.add(new PedPerson("ped", "Adam", "0", "0", Sex.MALE, Disease.AFFECTED)); // Father
+		individuals.add(new PedPerson("ped", "Seth", "Adam", "Eva", Sex.MALE, Disease.AFFECTED)); // Child
+		pedFileContents = new PedFileContents(new ImmutableList.Builder<String>().build(), individuals.build());
+		pedigreeAffectedTwoAffected = new Pedigree(pedFileContents, "ped");
+
+		jannovarDB = new TestJannovarDataFactory().getJannovarData();
+
+		reader = new VCFFileReader(inheritanceFilterVCFPath.toFile(),false);
+		variants = new ArrayList<VariantContext>();
+		for (VariantContext variantContext : reader) {
+			variants.add(variantContext);
+		}
+
+	}
+
+	@Test
+	public void pedigreeAffectedChildADTest() {
+		WriterFilterHelper helper = new WriterFilterHelper();
+		GeneWiseInheritanceFilter filter = new GeneWiseInheritanceFilter(pedigreeAffectedChild, jannovarDB,
+				ImmutableSet.of(ModeOfInheritance.AUTOSOMAL_DOMINANT), helper);
+		List<FlaggedVariant> flaggedVariants = getFlaggedVariants();
+		try {
+			for (FlaggedVariant fv : flaggedVariants) {
+				filter.put(fv);
+			}
+			filter.finish();
+		} catch (FilterException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		List<VariantContext> vars = helper.getVariants();
+		
+		Assert.assertTrue(!vars.isEmpty());
+		Assert.assertTrue(vars.size() == 1);
+		Assert.assertEquals(vars.iterator().next().getStart(), 145515898);
+
+	}
+	
+	@Test
+	public void pedigreeAffectedChildARTest() {
+		WriterFilterHelper helper = new WriterFilterHelper();
+		GeneWiseInheritanceFilter filter = new GeneWiseInheritanceFilter(pedigreeAffectedChild, jannovarDB,
+				ImmutableSet.of(ModeOfInheritance.AUTOSOMAL_RECESSIVE), helper);
+		List<FlaggedVariant> flaggedVariants = getFlaggedVariants();
+		try {
+			for (FlaggedVariant fv : flaggedVariants) {
+				filter.put(fv);
+			}
+			filter.finish();
+		} catch (FilterException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		List<VariantContext> vars = helper.getVariants();
+		
+		Assert.assertTrue(!vars.isEmpty());
+		Assert.assertTrue(vars.size() == 3);
+		Iterator<VariantContext> vcIt = vars.iterator();
+		Assert.assertEquals(vcIt.next().getStart(), 145513532);
+		Assert.assertEquals(vcIt.next().getStart(), 145513534);
+		Assert.assertEquals(vcIt.next().getStart(), 123239370);
+
+	}
+	
+	@Test
+	public void pedigreeTwoAffectedADTest() {
+		WriterFilterHelper helper = new WriterFilterHelper();
+		GeneWiseInheritanceFilter filter = new GeneWiseInheritanceFilter(pedigreeAffectedTwoAffected, jannovarDB,
+				ImmutableSet.of(ModeOfInheritance.AUTOSOMAL_DOMINANT), helper);
+		List<FlaggedVariant> flaggedVariants = getFlaggedVariants();
+		try {
+			for (FlaggedVariant fv : flaggedVariants) {
+				filter.put(fv);
+			}
+			filter.finish();
+		} catch (FilterException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		List<VariantContext> vars = helper.getVariants();
+		
+		Assert.assertTrue(!vars.isEmpty());
+		Assert.assertTrue(vars.size() == 1);
+		Assert.assertEquals(vars.iterator().next().getStart(), 145513532);
+
+	}
+	
+	@Test
+	public void pedigreeTwoAffectedARTest() {
+		WriterFilterHelper helper = new WriterFilterHelper();
+		GeneWiseInheritanceFilter filter = new GeneWiseInheritanceFilter(pedigreeAffectedTwoAffected, jannovarDB,
+				ImmutableSet.of(ModeOfInheritance.AUTOSOMAL_RECESSIVE), helper);
+		List<FlaggedVariant> flaggedVariants = getFlaggedVariants();
+		try {
+			for (FlaggedVariant fv : flaggedVariants) {
+				filter.put(fv);
+			}
+			filter.finish();
+		} catch (FilterException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		List<VariantContext> vars = helper.getVariants();
+		
+		Assert.assertTrue(!vars.isEmpty());
+		Assert.assertTrue(vars.size() == 1);
+		Iterator<VariantContext> vcIt = vars.iterator();
+		Assert.assertEquals(vcIt.next().getStart(), 123357972);
+
+	}
+
+	private List<FlaggedVariant> getFlaggedVariants() {
+		List<FlaggedVariant> output = new ArrayList<FlaggedVariant>();
+		for (VariantContext vc : variants) {
+			output.add(new FlaggedVariant(vc));
+		}
+		return output;
+	}
+
+}

--- a/jannovar-filter/src/test/resources/inheritanceFilterCHRTest.vcf
+++ b/jannovar-filter/src/test/resources/inheritanceFilterCHRTest.vcf
@@ -1,0 +1,14 @@
+##fileformat=VCFv4.1
+##Another comment line.
+##description=This file contains a few variants for inheritance testing. 
+##description=The gene RBM8A matches AUTOSOMAL_DOMINANT (trio, child+father affected, chr1:145513532 -> het affected HOM_REF unaffected) and AUTOSOMAL_RECESSIVE (trio, child affected, chr1:145513532	 + chr1:145513534 -> compoundHet)
+##description=The gene GNRHR2 matches AUTOSOMAL_DOMINANT (trio, child affected, chr1:145515898 deNovo)
+##description=The gene FGFR2 matches AUTOSOMAL_RECESSIVE (trio, child affected, chr1:123239370 HOM_Alt child and HET parents)
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Seth	Adam	Eva
+chr1	145513532	.	CA	CC	100.15	PASS	GENE=RBM8A	GT:DP	0/1:33	0/1:33	0/0:33
+chr1	145513533	.	T	C	123.15	PASS	GENE=RBM8A	GT:DP	1/1:21	1/1:33	1/1:33
+chr1	145513534	rs12345678	T	C	123.15	PASS	GENE=RBM8A	GT:DP	0/1:21	0/0:33	1/0:33
+chr1	145515898	rs23456789	G	A	260.15	PASS	GENE=GNRHR2	GT:DP	0/1:21	0/0:33	0/0:33
+chr1	145515899	.	G	A	260.15	PASS	GENE=GNRHR2	GT:DP	0/1:21	0/1:33	0/1:33
+chr10	123357972	.	G	A	260.15	PASS	GENE=FGFR2	GT:DP	1/1:21	1/1:33	0/1:33
+chr10	123239370	.	G	A	260.15	PASS	GENE=FGFR2	GT:DP	1/1:21	0/1:33	0/1:33

--- a/jannovar-filter/src/test/resources/inheritanceFilterTest.vcf
+++ b/jannovar-filter/src/test/resources/inheritanceFilterTest.vcf
@@ -1,8 +1,8 @@
 ##fileformat=VCFv4.1
 ##Another comment line.
 ##description=This file contains a few variants for inheritance testing. 
-##description=The gene RBM8A matches AUTOSOMAL_DOMINANT (trio, child+father affected, chr1:123256213 -> het affected HOM_REF unaffected) and AUTOSOMAL_RECESSIVE (trio, child affected, chr1:145508800 + chr1:123256213 -> compoundHet)
-##description=The gene GNRHR2 matches AUTOSOMAL_DOMINANT (trio, child affected, chr1:145510000 deNovo)
+##description=The gene RBM8A matches AUTOSOMAL_DOMINANT (trio, child+father affected, chr1:145513532 -> het affected HOM_REF unaffected) and AUTOSOMAL_RECESSIVE (trio, child affected, chr1:145513532 + chr1:145513534 -> compoundHet)
+##description=The gene GNRHR2 matches AUTOSOMAL_DOMINANT (trio, child affected, chr1:145515898 deNovo)
 ##description=The gene FGFR2 matches AUTOSOMAL_RECESSIVE (trio, child affected, chr1:123239370 HOM_Alt child and HET parents)
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Seth	Adam	Eva
 1	145513532	.	CA	CC	100.15	PASS	GENE=RBM8A	GT:DP	0/1:33	0/1:33	0/0:33

--- a/jannovar-inheritance-checker/src/main/java/de/charite/compbio/jannovar/pedigree/InheritanceVariantContextList.java
+++ b/jannovar-inheritance-checker/src/main/java/de/charite/compbio/jannovar/pedigree/InheritanceVariantContextList.java
@@ -79,7 +79,7 @@ public final class InheritanceVariantContextList {
 	 * @return <code>true</code> if the contig of the variant is on one of the autosomes (chr1-chr22|1-22)
 	 */
 	private boolean isAutosomal(VariantContext vc) {
-		return vc.getContig().toLowerCase().matches("(^chr([0-9])|(1[0-9])|(2[012])$)|(^([0-9])|(1[0-9])|(2[012])$)");
+		return vc.getContig().toLowerCase().matches("(^chr([0-9])|(chr1[0-9])|(chr2[012])$)|(^([0-9])|(1[0-9])|(2[012])$)");
 	}
 
 	/**

--- a/jannovar-inheritance-checker/src/main/java/de/charite/compbio/jannovar/pedigree/InheritanceVariantContextList.java
+++ b/jannovar-inheritance-checker/src/main/java/de/charite/compbio/jannovar/pedigree/InheritanceVariantContextList.java
@@ -79,7 +79,7 @@ public final class InheritanceVariantContextList {
 	 * @return <code>true</code> if the contig of the variant is on one of the autosomes (chr1-chr22|1-22)
 	 */
 	private boolean isAutosomal(VariantContext vc) {
-		return vc.getContig().toLowerCase().matches("(^chr([0-9])|(chr1[0-9])|(chr2[012])$)|(^([0-9])|(1[0-9])|(2[012])$)");
+		return vc.getContig().toLowerCase().matches("(^chr(([0-9])|(1[0-9])|(2[012]))$)|(^([0-9])|(1[0-9])|(2[012])$)");
 	}
 
 	/**


### PR DESCRIPTION
big bug in jannovar inheritance checker. fixes two problems. 

1. constructs a tree map inGeneWiseInheritanceFilter with contigs 1,2,3,... AND chr1,chr2,...
2. Pattern to detect autosomal chromosomes was wrong (for chr10-chr22)