### PR TITLE
hotfix: intronic 5' or 3' UTR variants are missclassified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Jannovar Changelog
 
-## develop
+## 0.16.1
+
+* hotfix about intronic variants between 5' or 3' UTRs. These variants were misclassified as FIVE_PRIME_UTR_VARIANT or THREE_PRIME_UTR_VARIANT. Now they are CODING_TRANSCRIPT_INTRON_VARIANT or NON_CODING_TRANSCRIPT_INTRON_VARIANT (if coding or non-coding transcript). We suggest new terms like FIVE_PRIME_UTR_INTRON_VARIANT but right now, they are not in the SequenceOntology.
+
+## 0.16
 
 ### jannovar-cli
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
@@ -242,11 +242,29 @@ abstract class AnnotationBuilder {
 			else if ((so.liesInSpliceRegion(lPos) && so.liesInSpliceRegion(pos)))
 				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
 			// Check for being in 5' or 3' UTR.
-			if (so.liesInFivePrimeUTR(lPos))
-				varTypes.add(VariantEffect.FIVE_PRIME_UTR_VARIANT);
-			else
-				// so.liesInThreePrimeUTR(pos)
-				varTypes.add(VariantEffect.THREE_PRIME_UTR_VARIANT);
+			if (so.liesInFivePrimeUTR(lPos)) {
+				// Check if variant overlaps really with an UTR
+				if (so.liesInExon(lPos))
+					varTypes.add(VariantEffect.FIVE_PRIME_UTR_VARIANT);
+				else {
+					// between two UTRs. check for coding or non-coding transcript.
+					if (transcript.isCoding())
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+					else
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+				}
+			} else {
+				// Check if variant overlaps really with an UTR
+				if (so.liesInExon(lPos))
+					varTypes.add(VariantEffect.THREE_PRIME_UTR_VARIANT);
+				else {
+					// between two UTRs. check for coding or non-coding transcript.
+					if (transcript.isCoding())
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+					else
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+				}
+			}
 		} else {
 			GenomeInterval changeInterval = change.getGenomeInterval();
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
@@ -257,11 +275,29 @@ abstract class AnnotationBuilder {
 			else if (so.overlapsWithSpliceRegion(changeInterval))
 				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
 			// Check for being in 5' or 3' UTR.
-			if (so.overlapsWithFivePrimeUTR(change.getGenomeInterval()))
-				varTypes.add(VariantEffect.FIVE_PRIME_UTR_VARIANT);
-			else
-				// so.overlapsWithThreePrimeUTR(change.getGenomeInterval())
-				varTypes.add(VariantEffect.THREE_PRIME_UTR_VARIANT);
+			if (so.overlapsWithFivePrimeUTR(changeInterval)) {
+				// Check if variant overlaps really with an UTR
+				if (so.overlapsWithExon(changeInterval))
+					varTypes.add(VariantEffect.FIVE_PRIME_UTR_VARIANT);
+				else {
+					// between two UTRs. check for coding or non-coding transcript.
+					if (transcript.isCoding())
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+					else
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+				}
+			} else {
+				// Check if variant overlaps really with an UTR
+				if (so.overlapsWithExon(changeInterval))
+					varTypes.add(VariantEffect.THREE_PRIME_UTR_VARIANT);
+				else {
+					// between two UTRs. check for coding or non-coding transcript.
+					if (transcript.isCoding())
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+					else
+						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+				}
+			}
 		}
 		return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(),
 				ProteinMiscChange.build(true, ProteinMiscChangeType.NO_CHANGE));

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -667,7 +667,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals("-70_-70+1insA", annoInsertionAfterExon1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annoInsertionAfterExon1.getProteinChange().toHGVSString()); // XXX
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
 				annoInsertionAfterExon1.getEffects());
 
 		GenomeVariant varInsertionAfterExon2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6641359,

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -667,7 +667,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals("-70_-70+1insA", annoInsertionAfterExon1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annoInsertionAfterExon1.getProteinChange().toHGVSString()); // XXX
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_VARIANT),
 				annoInsertionAfterExon1.getEffects());
 
 		GenomeVariant varInsertionAfterExon2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6641359,
@@ -703,7 +703,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals("-69-1_-69insA", annoInsertionBeforeExon1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annoInsertionBeforeExon1.getProteinChange().toHGVSString());
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
 				annoInsertionBeforeExon1.getEffects());
 
 		GenomeVariant varInsertionBeforeExon2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6642117,

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
@@ -214,7 +214,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals("-70+1G>A", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT, VariantEffect.SPLICE_DONOR_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT, VariantEffect.SPLICE_DONOR_VARIANT),
 				anno.getEffects());
 	}
 
@@ -228,7 +228,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals("-69-1G>A", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT, VariantEffect.SPLICE_ACCEPTOR_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT, VariantEffect.SPLICE_ACCEPTOR_VARIANT),
 				anno.getEffects());
 	}
 
@@ -2958,7 +2958,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-58+141C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -2987,7 +2987,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-57-23C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3017,7 +3017,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*40+38C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3046,7 +3046,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*41-164T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3133,7 +3133,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-174-93T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3160,7 +3160,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-175+69A>G", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3189,7 +3189,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*38-90T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3218,7 +3218,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*37+65A>G", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**


### PR DESCRIPTION
variants that are between two 5' or 3' UTR exons are miss-classified as FIVE_PRIME_UTR_VARIANT or THREE_PRIME_UTR_VARIANT. With this fix they
are CODING_TRANSCRIPT_INTRON_VARIANT or
NON_CODING_TRANSCRIPT_INTRON_VARIANT