### PR TITLE
adding new sequence ontology terms to the VariantEffect class. (UTR_Exon/UTR_Intron)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Rewrite of GFF parsers for RefSeq and ENSEMBL.
 * Bumping HTSJDK to 2.1.0, requiring Java 8 from now on.
 * Removal of `AnnotationCollector`, priotization of variant effects is done after collecting all effect predictions now.
-* Fix for intronic variants between 5' or 3' UTRs. These variants were misclassified as `FIVE_PRIME_UTR_VARIANT` or `THREE_PRIME_UTR_VARIANT`. Now they are `CODING_TRANSCRIPT_INTRON_VARIANT` or `NON_CODING_TRANSCRIPT_INTRON_VARIANT` (if coding or non-coding transcript). We suggest new terms like `FIVE_PRIME_UTR_INTRON_VARIANT` but right now, they are not in the SequenceOntology.
+* Fix for intronic variants between 5' or 3' UTRs. These variants were misclassified as `FIVE_PRIME_UTR_VARIANT` or `THREE_PRIME_UTR_VARIANT`. SequenceOntology implements new terms so that we can decide between the two UTR exon and intron variants. Now we have `FIVE_PRIME_UTR_EXON_VARIANT` or `FIVE_PRIME_UTR_EXON_INTRON_VARIANT` (the same for `THREE_PRIME_UTR_EXON_VARIANT` or `THREE_PRIME_UTR_EXON_INTRON_VARIANT`).
 
 ## v0.16
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantEffect.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantEffect.java
@@ -16,6 +16,7 @@ import com.google.common.base.Predicate;
  * @author <a href="mailto:peter.robinson@charite.de">Peter Robinson</a>
  * @author <a href="mailto:marten.jaeger@charite.de">Marten Jaeger</a>
  * @author <a href="mailto:manuel.holtgrewe@charite.de">Manuel Holtgrewe</a>
+ * @author <a href="mailto:max.schubach@charite.de">Max Schubach</a>
  */
 public enum VariantEffect {
 
@@ -270,15 +271,25 @@ public enum VariantEffect {
 	// TODO(holtgrem): use
 	FIVE_PRIME_UTR_PREMATURE_START_CODON_GAIN_VARIANT,
 	/**
-	 * <a href="http://www.sequenceontology.org/browser/current_svn/term/SO:0001623">SO:0001623</a> A UTR variant of the
-	 * 5' UTR (is a: UTR_variant).
+	 * <a href="http://www.sequenceontology.org/browser/current_svn/term/SO:0002092">SO:0002092</a> A UTR variant of the
+	 * 5' UTR (is a: 5_prime_UTR_variant; is a: UTR_variant).
 	 */
-	FIVE_PRIME_UTR_VARIANT,
+	FIVE_PRIME_UTR_EXON_VARIANT,
 	/**
-	 * <a href="http://www.sequenceontology.org/browser/current_svn/term/SO:0001624">SO:0001624</a> A UTR variant of the
-	 * 3' UTR (is a: UTR_variant).
+	 * <a href="http://www.sequenceontology.org/browser/current_svn/term/SO:0002089">SO:0002089</a> A UTR variant of the
+	 * 3' UTR (is a: 3_prime_UTR_variant; is a: UTR_variant).
 	 */
-	THREE_PRIME_UTR_VARIANT,
+	THREE_PRIME_UTR_EXON_VARIANT,
+	/**
+	 * <a href="http://www.sequenceontology.org/browser/current_svn/term/SO:0002091">SO:0002091</a> A UTR variant between
+	 * 5' UTRs (is a: 5_prime_UTR_variant; is a: UTR_variant).
+	 */
+	FIVE_PRIME_UTR_INTRON_VARIANT,
+	/**
+	 * <a href="http://www.sequenceontology.org/browser/current_svn/term/SO:0002090">SO:0002090</a> A UTR variant between
+	 * 3' UTRs (is a: 3_prime_UTR_variant; is a: UTR_variant).
+	 */
+	THREE_PRIME_UTR_INTRON_VARIANT,
 
 	/**
 	 * Marker for smallest {@link VariantEffect} with {@link PutativeImpact#LOW} impact.
@@ -529,7 +540,7 @@ public enum VariantEffect {
 			return "DOWNSTREAM";
 		case FIVE_PRIME_UTR_PREMATURE_START_CODON_GAIN_VARIANT:
 		case FIVE_PRIME_UTR_TRUNCATION:
-		case FIVE_PRIME_UTR_VARIANT:
+		case FIVE_PRIME_UTR_EXON_VARIANT:
 			return "UTR5";
 		case FRAMESHIFT_ELONGATION:
 			return "FS_INSERTION";
@@ -551,6 +562,8 @@ public enum VariantEffect {
 		case CONSERVED_INTRON_VARIANT:
 		case CODING_TRANSCRIPT_INTRON_VARIANT:
 		case INTRON_VARIANT:
+		case FIVE_PRIME_UTR_INTRON_VARIANT:
+		case THREE_PRIME_UTR_INTRON_VARIANT:
 			return "INTRONIC";
 		case MNV:
 			return "NON_FS_SUBSTITUTION";
@@ -576,7 +589,7 @@ public enum VariantEffect {
 		case SYNONYMOUS_VARIANT:
 			return "SYNONYMOUS";
 		case THREE_PRIME_UTR_TRUNCATION:
-		case THREE_PRIME_UTR_VARIANT:
+		case THREE_PRIME_UTR_EXON_VARIANT:
 			return "UTR3";
 		case TRANSCRIPT_ABLATION:
 			return "TRANSCRIPT_ABLATION";
@@ -663,9 +676,11 @@ public enum VariantEffect {
 		case FIVE_PRIME_UTR_PREMATURE_START_CODON_GAIN_VARIANT:
 			return "5_prime_UTR_premature_start_codon_gain_variant";
 		case FIVE_PRIME_UTR_TRUNCATION:
-			return "5_prime_utr_truncation";
-		case FIVE_PRIME_UTR_VARIANT:
-			return "5_prime_utr_variant";
+			return "5_prime_UTR_truncation";
+		case FIVE_PRIME_UTR_EXON_VARIANT:
+			return "5_prime_UTR_exon_variant";
+		case FIVE_PRIME_UTR_INTRON_VARIANT:
+			return "5_prime_UTR_intron_variant";
 		case FRAMESHIFT_ELONGATION:
 			return "frameshift_elongation";
 		case FRAMESHIFT_TRUNCATION:
@@ -729,9 +744,11 @@ public enum VariantEffect {
 		case TF_BINDING_SITE_VARIANT:
 			return "tf_binding_site_variant";
 		case THREE_PRIME_UTR_TRUNCATION:
-			return "3_prime_utr_truncation";
-		case THREE_PRIME_UTR_VARIANT:
-			return "3_prime_utr_variant";
+			return "3_prime_UTR_truncation";
+		case THREE_PRIME_UTR_EXON_VARIANT:
+			return "3_prime_UTR_exon_variant";
+		case THREE_PRIME_UTR_INTRON_VARIANT:
+			return "3_prime_UTR_intron_variant";
 		case TRANSCRIPT_ABLATION:
 			return "transcript_ablation";
 		case TRANSCRIPT_VARIANT:
@@ -790,8 +807,10 @@ public enum VariantEffect {
 			return "SO:0001983";
 		case FIVE_PRIME_UTR_TRUNCATION:
 			return "SO:0002013";
-		case FIVE_PRIME_UTR_VARIANT:
-			return "SO:0001623";
+		case FIVE_PRIME_UTR_EXON_VARIANT:
+			return "SO:0002092";
+		case FIVE_PRIME_UTR_INTRON_VARIANT:
+			return "SO:0002091";
 		case FRAMESHIFT_ELONGATION:
 			return "SO:0001909";
 		case FRAMESHIFT_TRUNCATION:
@@ -856,8 +875,10 @@ public enum VariantEffect {
 			return "SO:0001819 ";
 		case THREE_PRIME_UTR_TRUNCATION:
 			return "SO:0001819 ";
-		case THREE_PRIME_UTR_VARIANT:
-			return "SO:0001624";
+		case THREE_PRIME_UTR_EXON_VARIANT:
+			return "SO:0002089";
+		case THREE_PRIME_UTR_INTRON_VARIANT:
+			return "SO:0002090";
 		case TRANSCRIPT_ABLATION:
 			return "SO:0001624";
 		case TRANSCRIPT_VARIANT:
@@ -969,9 +990,11 @@ public enum VariantEffect {
 		switch (this) {
 		case CODING_TRANSCRIPT_INTRON_VARIANT:
 		case FIVE_PRIME_UTR_TRUNCATION:
-		case FIVE_PRIME_UTR_VARIANT:
+		case FIVE_PRIME_UTR_INTRON_VARIANT:
+		case FIVE_PRIME_UTR_EXON_VARIANT:
 		case THREE_PRIME_UTR_TRUNCATION:
-		case THREE_PRIME_UTR_VARIANT:
+		case THREE_PRIME_UTR_EXON_VARIANT:
+		case THREE_PRIME_UTR_INTRON_VARIANT:
 		case NON_CODING_TRANSCRIPT_INTRON_VARIANT:
 		case NON_CODING_TRANSCRIPT_VARIANT:
 			return false;

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
@@ -245,24 +245,24 @@ abstract class AnnotationBuilder {
 			if (so.liesInFivePrimeUTR(lPos)) {
 				// Check if variant overlaps really with an UTR
 				if (so.liesInExon(lPos))
-					varTypes.add(VariantEffect.FIVE_PRIME_UTR_VARIANT);
+					varTypes.add(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT);
 				else {
 					// between two UTRs. check for coding or non-coding transcript.
 					if (transcript.isCoding())
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT);
 					else
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT);
 				}
 			} else {
 				// Check if variant overlaps really with an UTR
 				if (so.liesInExon(lPos))
-					varTypes.add(VariantEffect.THREE_PRIME_UTR_VARIANT);
+					varTypes.add(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT);
 				else {
 					// between two UTRs. check for coding or non-coding transcript.
 					if (transcript.isCoding())
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT);
 					else
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT);
 				}
 			}
 		} else {
@@ -278,24 +278,24 @@ abstract class AnnotationBuilder {
 			if (so.overlapsWithFivePrimeUTR(changeInterval)) {
 				// Check if variant overlaps really with an UTR
 				if (so.overlapsWithExon(changeInterval))
-					varTypes.add(VariantEffect.FIVE_PRIME_UTR_VARIANT);
+					varTypes.add(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT);
 				else {
 					// between two UTRs. check for coding or non-coding transcript.
 					if (transcript.isCoding())
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT);
 					else
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT);
 				}
 			} else {
 				// Check if variant overlaps really with an UTR
 				if (so.overlapsWithExon(changeInterval))
-					varTypes.add(VariantEffect.THREE_PRIME_UTR_VARIANT);
+					varTypes.add(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT);
 				else {
 					// between two UTRs. check for coding or non-coding transcript.
 					if (transcript.isCoding())
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT);
 					else
-						varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
+						varTypes.add(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT);
 				}
 			}
 		}

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
@@ -146,7 +146,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-195_-193delACGinsCGTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -158,7 +158,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*58_*60delACGinsCGGTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -150,7 +150,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-192del", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -163,7 +163,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*59del", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -1010,7 +1010,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-25del", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -1034,7 +1034,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-7_-6del", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -1058,7 +1058,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-11_-5del", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -130,7 +130,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(1, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("-1dup", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), anno.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
 	@Test
@@ -142,7 +142,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(10, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("2067_*1insA", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), anno.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
 	@Test
@@ -667,7 +667,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals("-70_-70+1insA", annoInsertionAfterExon1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annoInsertionAfterExon1.getProteinChange().toHGVSString()); // XXX
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT),
 				annoInsertionAfterExon1.getEffects());
 
 		GenomeVariant varInsertionAfterExon2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6641359,
@@ -703,7 +703,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals("-69-1_-69insA", annoInsertionBeforeExon1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annoInsertionBeforeExon1.getProteinChange().toHGVSString());
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT),
 				annoInsertionBeforeExon1.getEffects());
 
 		GenomeVariant varInsertionBeforeExon2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6642117,
@@ -750,7 +750,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*255dup", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -774,7 +774,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-37_-36insCTT", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -1770,7 +1770,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*28_*29insTA", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -1797,7 +1797,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*18_*21dup", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -1826,7 +1826,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(8, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*5_*6insGACA", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	// The following variant from the Platinum Genome project caused problems against hg19/ucsc:

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
@@ -138,7 +138,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(10, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("*1T>A", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), anno.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
 	@Test
@@ -150,7 +150,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(1, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("-1T>A", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), anno.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
 	@Test
@@ -214,7 +214,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals("-70+1G>A", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT, VariantEffect.SPLICE_DONOR_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT, VariantEffect.SPLICE_DONOR_VARIANT),
 				anno.getEffects());
 	}
 
@@ -228,7 +228,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals("-69-1G>A", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT, VariantEffect.SPLICE_ACCEPTOR_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT, VariantEffect.SPLICE_ACCEPTOR_VARIANT),
 				anno.getEffects());
 	}
 
@@ -243,7 +243,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals("-67G>A", anno.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
 		Assert.assertEquals(
-				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
+				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				anno.getEffects());
 		// in CDS
 		GenomeVariant change2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6647537,
@@ -1528,7 +1528,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-118T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -1969,7 +1969,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(36, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*51G>A", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -1992,7 +1992,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-74A>G", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2015,7 +2015,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*148C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2038,7 +2038,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-39C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2061,7 +2061,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-10A>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2084,7 +2084,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-37T>G", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2106,7 +2106,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-3T>G", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2129,7 +2129,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-49G>A", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2152,7 +2152,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-393T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2175,7 +2175,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-62T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2198,7 +2198,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-33G>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2221,7 +2221,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-725G>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	@Test
@@ -2604,7 +2604,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals("20620683G>A", annotation1.getGenomicNTChange().toHGVSString());
 		Assert.assertEquals("*51G>A", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	//
@@ -2823,7 +2823,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*66C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
 	//
@@ -2958,7 +2958,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-58+141C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -2987,7 +2987,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-57-23C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3017,7 +3017,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*40+38C>T", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3046,7 +3046,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*41-164T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3133,7 +3133,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-174-93T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3160,7 +3160,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-175+69A>G", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3189,7 +3189,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*38-90T>C", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**
@@ -3218,7 +3218,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*37+65A>G", annotation1.getCDSNTChange().toHGVSString());
 		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
-		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/The-Sequence-Ontology/SO-Ontologies/issues/346

Now Jannovar can decide between UTR exon and UTR intron variants.