### PR TITLE
WIP: Sample of using argparse4j in Jannovar

### DIFF
--- a/jannovar-cli/pom.xml
+++ b/jannovar-cli/pom.xml
@@ -1,189 +1,200 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<artifactId>jannovar-cli</artifactId>
-	<packaging>jar</packaging>
+    <artifactId>jannovar-cli</artifactId>
+    <packaging>jar</packaging>
 
-	<name>${project.groupId}:${project.artifactId}</name>
-	<description>jannovar-cli is the command line interface for Jannovar</description>
-	<url>http://charite.github.io/jannovar/</url>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>jannovar-cli is the command line interface for Jannovar</description>
+    <url>http://charite.github.io/jannovar/</url>
 
-	<parent>
-		<groupId>de.charite.compbio</groupId>
-		<artifactId>Jannovar</artifactId>
-		<version>0.17-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>de.charite.compbio</groupId>
+        <artifactId>Jannovar</artifactId>
+        <version>0.17-SNAPSHOT</version>
+    </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-	<dependencies>
-		<!-- Simple logging for console -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.12</version>
-		</dependency>
-		<!--commons-cli used for parsing the command line -->
-		<dependency>
-			<groupId>commons-cli</groupId>
-			<artifactId>commons-cli</artifactId>
-			<version>1.3.1</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.samtools</groupId>
-			<artifactId>htsjdk</artifactId>
-			<version>${htsjdk.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.tukaani</groupId>
-					<artifactId>xz</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>19.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.ini4j</groupId>
-			<artifactId>ini4j</artifactId>
-			<version>0.5.1</version>
-		</dependency>
+    <dependencies>
+        <!-- Simple logging for console -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.12</version>
+        </dependency>
+        <!--commons-cli used for parsing the command line -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <!-- argparse4j is a nice command line parsing library -->
+        <dependency>
+            <groupId>net.sourceforge.argparse4j</groupId>
+            <artifactId>argparse4j</artifactId>
+            <version>0.7.0</version>
+        </dependency>
+        <!-- HTSJDK for FASTA/VCF file access -->
+        <dependency>
+            <groupId>com.github.samtools</groupId>
+            <artifactId>htsjdk</artifactId>
+            <version>${htsjdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.tukaani</groupId>
+                    <artifactId>xz</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ini4j</groupId>
+            <artifactId>ini4j</artifactId>
+            <version>0.5.1</version>
+        </dependency>
         <!-- Jannovar modules -->
-		<dependency>
-			<groupId>de.charite.compbio</groupId>
-			<artifactId>jannovar-core</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>de.charite.compbio</groupId>
-			<artifactId>jannovar-htsjdk</artifactId>
-			<version>${project.version}</version>
-		</dependency>
+        <dependency>
+            <groupId>de.charite.compbio</groupId>
+            <artifactId>jannovar-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.charite.compbio</groupId>
+            <artifactId>jannovar-htsjdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>de.charite.compbio</groupId>
             <artifactId>jannovar-vardbs</artifactId>
             <version>${project.version}</version>
         </dependency>
-		<!-- Logging -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-	</dependencies>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-				<!--Use filtering so that maven will replace placeholders with values 
-					from the pom e.g. ${project.version} -->
-				<filtering>true</filtering>
-			</resource>
-		</resources>
-		<plugins>
-			<!-- Make an executable jar and specify the main class and classpath -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.5</version>
-				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<classpathPrefix>lib/</classpathPrefix>
-							<!-- set useUniqueVersions=false in order that the classpath has the 
-								SNAPSHOT instead of the build number prefixed to the dependency -->
-							<useUniqueVersions>false</useUniqueVersions>
-							<mainClass>de.charite.compbio.jannovar.Jannovar</mainClass>
-						</manifest>
-					</archive>
-					<compilerArgument>-Xlint:all</compilerArgument>
-					<showWarnings>true</showWarnings>
-					<showDeprecation>true</showDeprecation>
-				</configuration>
-			</plugin>
-			<!-- More JAR building -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.2</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>de.charite.compbio.jannovar.Jannovar</mainClass>
-								</transformer>
-							</transformers>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<!-- Specify the resources which need to be made accessible to the user -->
-			<plugin>
-				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.6</version>
-				<executions>
-					<execution>
-						<id>copy-resources</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>copy-resources</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.directory}/resources</outputDirectory>
-							<resources>
-								<resource>
-									<directory>src/resources</directory>
-									<!--Use filtering so that maven will replace placeholders with values 
-										from the pom e.g. ${project.version} -->
-									<filtering>true</filtering>
-									<includes>
-										<include>application.properties</include>
-										<include>example.settings</include>
-										<include>test.settings</include>
-										<include>log4j2.xml</include>
-									</includes>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<!--This plugin assembles the various elements together into a redistributable 
-				zip/tar.gz file -->
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<descriptors>
-						<descriptor>src/assembly/dep.xml</descriptor>
-					</descriptors>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-assembly</id> <!-- this is used for inheritance merges -->
-						<phase>package</phase> <!-- bind to the packaging phase -->
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <!--Use filtering so that maven will replace placeholders 
+                    with values from the pom e.g. ${project.version} -->
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <!-- Make an executable jar and specify the main class and classpath -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <!-- set useUniqueVersions=false in order that 
+                                the classpath has the SNAPSHOT instead of the build number prefixed to the 
+                                dependency -->
+                            <useUniqueVersions>false</useUniqueVersions>
+                            <mainClass>de.charite.compbio.jannovar.Jannovar</mainClass>
+                        </manifest>
+                    </archive>
+                    <compilerArgument>-Xlint:all</compilerArgument>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+            <!-- More JAR building -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>de.charite.compbio.jannovar.Jannovar</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Specify the resources which need to be made accessible to 
+                the user -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/resources</directory>
+                                    <!--Use filtering so that maven will 
+                                        replace placeholders with values from the pom e.g. ${project.version} -->
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>application.properties</include>
+                                        <include>example.settings</include>
+                                        <include>test.settings</include>
+                                        <include>log4j2.xml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--This plugin assembles the various elements together into 
+                a redistributable zip/tar.gz file -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/dep.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/Jannovar.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/Jannovar.java
@@ -1,6 +1,7 @@
 package de.charite.compbio.jannovar;
 
-/** Command line functions from apache */
+import java.io.PrintWriter;
+
 import de.charite.compbio.jannovar.cmd.CommandLineParsingException;
 import de.charite.compbio.jannovar.cmd.HelpRequestedException;
 import de.charite.compbio.jannovar.cmd.JannovarCommand;
@@ -8,72 +9,42 @@ import de.charite.compbio.jannovar.cmd.annotate_pos.AnnotatePositionCommand;
 import de.charite.compbio.jannovar.cmd.annotate_vcf.AnnotateVCFCommand;
 import de.charite.compbio.jannovar.cmd.db_list.DatabaseListCommand;
 import de.charite.compbio.jannovar.cmd.download.DownloadCommand;
-import de.charite.compbio.jannovar.reference.TranscriptModel;
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.ArgumentGroup;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Subparsers;
 
 /**
- * This is the driver class for a program called Jannovar. It has two purposes
- * <OL>
- * <LI>Take the UCSC files knownGene.txt, kgXref.txt, knownGeneMrna.txt, and knownToLocusLink.txt, and to create
- * corresponding {@link TranscriptModel} objects and to serialize them. The resulting serialized file can be used both
- * by this program itself (see next item) or by the main Exomizer program to annotated VCF file.
- * <LI>Using the serialized file of {@link TranscriptModel} objects (see above item) annotate a VCF file using
- * annovar-type program logic. Note that this functionality is also used by the main Exomizer program and thus this
- * program can be used as a stand-alone annotator ("Jannovar") or as a way of testing the code for the Exomizer.
- * </OL>
- * <P>
- * To run the "Jannovar" executable:
- * <P>
- * {@code java -Xms1G -Xmx1G -jar Jannovar.jar -V xyz.vcf -D $SERIAL}
- * <P>
- * This will annotate a VCF file. The results of de.charite.compbio.jannovar annotation are shown in the form
- *
- * <PRE>
- * Annotation {original VCF line}
- * </PRE>
- * <P>
- * Just a reminder, to set up annovar to do this, use the following commands.
- *
- * <PRE>
- *   perl annotate_variation.pl --downdb knownGene --buildver hg19 humandb/
- * </PRE>
- *
- * then, to annotate a VCF file called BLA.vcf, we first need to convert it to Annovar input format and run the main
- * annovar program as follows.
- *
- * <PRE>
- * $ perl convert2annovar.pl BLA.vcf -format vcf4 &gt; BLA.av
- * $ perl annotate_variation.pl -buildver hg19 --geneanno BLA.av --dbtype knowngene humandb/
- * </PRE>
- *
- * This will create two files with all variants and a special file with exonic variants.
- * <p>
- * There are three ways of using this program.
- * <ol>
- * <li>To create a serialized version of the UCSC gene definition data. In this case, the command-line flag <b>- S</b>
- * is provide as is the path to the four UCSC files. Then, {@code anno.serialize()} is true and a file <b>ucsc.ser</b>
- * is created.
- * <li>To deserialize the serialized data (<b>ucsc.ser</b>). In this case, the flag <b>- D</b> must be used.
- * <li>To simply read in the UCSC data without creating a serialized file.
- * </ol>
- * Whichever of the three versions is chosen, the user may additionally pass the path to a VCF file using the <b>-v</b>
- * flag. If so, then this file will be annotated using the UCSC data, and a new version of the file will be written to a
- * file called test.vcf.jannovar (assuming the original file was named test.vcf). The
+ * The Jannovar main class is the gateway into the Jannovar CLI application
+ * 
+ * Call Jannovar with `--help` to see details on usage
  *
  * @author <a href="mailto:peter.robinson@charite.de">Peter N Robinson</a>
  * @author <a href="mailto:marten.jaeger@charite.de">Marten Jaeger</a>
  * @author <a href="mailto:max.schubach@charite.de">Max Schubach</a>
  */
 public final class Jannovar {
+
 	/** Configuration for the Jannovar program. */
 	JannovarOptions options = null;
 
 	public static void main(String argv[]) {
+		ArgumentParser parser = buildTopLevelParser();
+		try {
+			parser.parseArgs(argv);
+		} catch (ArgumentParserException e) {
+			parser.printHelp(new PrintWriter(System.err, true));
+			System.exit(1);
+		}
+
 		if (argv.length == 0) {
 			// No arguments, print top level help and exit.
 			printTopLevelHelp();
 			System.exit(1);
 		}
-		
+
 		String[] newArgs = new String[argv.length - 1];
 		for (int i = 0; i < newArgs.length; i++) {
 			newArgs[i] = argv[i + 1];
@@ -133,11 +104,27 @@ public final class Jannovar {
 		System.err.println("");
 		System.err.println("Example: java -jar de.charite.compbio.jannovar.jar download -d hg19/ucsc");
 		System.err.println("         java -jar de.charite.compbio.jannovar.jar db-list");
-		System.err
-				.println("         java -jar de.charite.compbio.jannovar.jar annotate -d data/hg19_ucsc.ser -i variants.vcf");
-		System.err
-				.println("         java -jar de.charite.compbio.jannovar.jar annotate-pos -d data/hg19_ucsc.ser -c 'chr1:12345C>A'");
+		System.err.println(
+				"         java -jar de.charite.compbio.jannovar.jar annotate -d data/hg19_ucsc.ser -i variants.vcf");
+		System.err.println(
+				"         java -jar de.charite.compbio.jannovar.jar annotate-pos -d data/hg19_ucsc.ser -c 'chr1:12345C>A'");
 		System.err.println("");
+	}
+
+	private static ArgumentParser buildTopLevelParser() {
+		ArgumentParser parser = ArgumentParsers.newArgumentParser("jannovar");
+
+		parser.addArgument("--verbose").action(Arguments.storeTrue()).help("Enable verbose logging");
+		parser.addArgument("--very-verbose").action(Arguments.storeTrue()).help("Enable very verbose logging");
+		
+		// Register sub commands with ArgumentParser
+		Subparsers subparsers = parser.addSubparsers();
+		DownloadCommand.addSubparser(subparsers);
+		DatabaseListCommand.addSubparser(subparsers);
+		AnnotatePositionCommand.addSubparser(subparsers);
+		AnnotateVCFCommand.addSubparser(subparsers);
+
+		return parser;
 	}
 
 }

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_pos/AnnotatePositionCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_pos/AnnotatePositionCommand.java
@@ -21,6 +21,9 @@ import de.charite.compbio.jannovar.reference.GenomePosition;
 import de.charite.compbio.jannovar.reference.GenomeVariant;
 import de.charite.compbio.jannovar.reference.PositionType;
 import de.charite.compbio.jannovar.reference.Strand;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.inf.Subparsers;
 
 /**
  * Allows the annotation of a single position.
@@ -110,6 +113,10 @@ public class AnnotatePositionCommand extends JannovarAnnotationCommand {
 		} catch (ParseException e) {
 			throw new CommandLineParsingException("Problem with command line parsing.", e);
 		}
+	}
+
+	public static void addSubparser(Subparsers subparsers) {
+		Subparser parser = subparsers.addParser("annotate-pos").help("Annotate predicted molecular inpact with Jannovar");
 	}
 
 }

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotateVCFCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotateVCFCommand.java
@@ -28,6 +28,9 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.inf.Subparsers;
 
 /**
  * Run annotation steps (read in VCF, write out VCF or Jannovar file format).
@@ -160,6 +163,15 @@ public class AnnotateVCFCommand extends JannovarAnnotationCommand {
 		} catch (ParseException e) {
 			throw new CommandLineParsingException("Could not parse the command line.", e);
 		}
+	}
+
+	/**
+	 * Register sub parsers in <code>parser</code>
+	 *
+	 * @param subparsers {@link ArgumentParser} to extend with a sub parser
+	 */
+	public static void addSubparser(Subparsers subparsers) {
+		Subparser parser = subparsers.addParser("annotate-vcf").help("Annoate a VCF file with Jannovar");
 	}
 
 }

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/db_list/DatabaseListCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/db_list/DatabaseListCommand.java
@@ -9,6 +9,9 @@ import de.charite.compbio.jannovar.cmd.HelpRequestedException;
 import de.charite.compbio.jannovar.cmd.JannovarCommand;
 import de.charite.compbio.jannovar.datasource.DataSourceFactory;
 import de.charite.compbio.jannovar.datasource.DatasourceOptions;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.inf.Subparsers;
 
 public class DatabaseListCommand extends JannovarCommand {
 
@@ -34,13 +37,17 @@ public class DatabaseListCommand extends JannovarCommand {
 	}
 
 	@Override
-	protected JannovarOptions parseCommandLine(String[] argv) throws CommandLineParsingException,
-			HelpRequestedException {
+	protected JannovarOptions parseCommandLine(String[] argv)
+			throws CommandLineParsingException, HelpRequestedException {
 		try {
 			return new DatabaseListCommandLineParser().parse(argv);
 		} catch (ParseException e) {
 			throw new CommandLineParsingException("Could not parse command line", e);
 		}
+	}
+
+	public static void addSubparser(Subparsers subparsers) {
+		Subparser parser = subparsers.addParser("db-list").help("List transcript databases to download");
 	}
 
 }

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/download/DownloadCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/download/DownloadCommand.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.cmd.download;
 
+import java.util.Map;
+
 import org.apache.commons.cli.ParseException;
 
 import de.charite.compbio.jannovar.JannovarException;
@@ -12,6 +14,10 @@ import de.charite.compbio.jannovar.data.JannovarDataSerializer;
 import de.charite.compbio.jannovar.datasource.DataSourceFactory;
 import de.charite.compbio.jannovar.datasource.DatasourceOptions;
 import de.charite.compbio.jannovar.impl.util.PathUtil;
+import net.sourceforge.argparse4j.inf.ArgumentGroup;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.inf.Subparsers;
 
 /**
  * Implementation of download step in Jannovar.
@@ -38,8 +44,8 @@ public final class DownloadCommand extends JannovarCommand {
 		DataSourceFactory factory = new DataSourceFactory(dsOptions, options.dataSourceFiles);
 		for (String name : options.dataSourceNames) {
 			System.err.println("Downloading/parsing for data source \"" + name + "\"");
-			JannovarData data = factory.getDataSource(name).getDataFactory()
-					.build(options.downloadPath, options.printProgressBars);
+			JannovarData data = factory.getDataSource(name).getDataFactory().build(options.downloadPath,
+					options.printProgressBars);
 			String filename = PathUtil.join(options.downloadPath, name.replace('/', '_').replace('\\', '_') + ".ser");
 			JannovarDataSerializer serializer = new JannovarDataSerializer(filename);
 			serializer.save(data);
@@ -47,13 +53,64 @@ public final class DownloadCommand extends JannovarCommand {
 	}
 
 	@Override
-	protected JannovarOptions parseCommandLine(String[] argv) throws CommandLineParsingException,
-	HelpRequestedException {
+	protected JannovarOptions parseCommandLine(String[] argv)
+			throws CommandLineParsingException, HelpRequestedException {
 		try {
 			return new DownloadCommandLineParser().parse(argv);
 		} catch (ParseException e) {
 			throw new CommandLineParsingException("Could not parse the command line.", e);
 		}
+	}
+
+	/**
+	 * Add sub parser for download command in <code>parser</code>
+	 *
+	 * @param subparsers
+	 *            {@link ArgumentParser} to add sub command to
+	 */
+	public static void addSubparser(Subparsers subparsers) {
+		Subparser parser = subparsers.addParser("download").help("Download database");
+
+		// Path to INI file with source list
+		parser.addArgument("--data-source-list").type(String.class).setDefault("bundle:///default_sources.ini")
+				.help("Path to INI file with data source list");
+		parser.addArgument("--data-dir").type(String.class).setDefault("data")
+				.help("target folder for downloaded and serialized files, defaults to \"data\"");
+
+		// Required argument: name of data source to download
+		parser.addArgument("-d", "--datasource").required(true).type(String.class).required(true)
+				.help("Name of the data source to download, get with 'db-list' command");
+
+		// Get proxy settings from system environment if possible
+		Map<String, String> env = System.getenv();
+		String httpProxy = null;
+		if (env.get("HTTP_PROXY") != null)
+			httpProxy = env.get("HTTP_PROXY");
+		if (env.get("http_proxy") != null)
+			httpProxy = env.get("http_proxy");
+		String httpsProxy = null;
+		if (env.get("HTTPS_PROXY") != null)
+			httpsProxy = env.get("HTTPS_PROXY");
+		if (env.get("https_proxy") != null)
+			httpsProxy = env.get("https_proxy");
+		String ftpProxy = null;
+		if (env.get("FTP_PROXY") != null)
+			ftpProxy = env.get("FTP_PROXY");
+		if (env.get("ftp_proxy") != null)
+			ftpProxy = env.get("ftp_proxy");
+
+		// Proxy configuration
+		ArgumentGroup proxyAG = parser.addArgumentGroup("Proxy settings");
+		proxyAG.description("Proxy settings, should have the format <proto>://<host>[:port]/");
+		proxyAG.addArgument("--proxy").type(String.class).help("Overall proxy, overridden by other more specific ones");
+		proxyAG.addArgument("--http-proxy").setDefault(httpProxy).type(String.class).help("HTTP proxy");
+		proxyAG.addArgument("--https-proxy").setDefault(httpsProxy).type(String.class).help("HTTPS proxy");
+		proxyAG.addArgument("--ftp-proxy").setDefault(ftpProxy).type(String.class).help("FTP proxy to use");
+
+		parser.description("Download database from ENSEMBL/UCSC/RefSeq etc. By default, the environment variables "
+				+ "http_proxy, https_proxy, ftp_proxy and the upper case variants are used if set.");
+
+		parser.epilog("Use this command to download a transcript database, e.g., using '-d hg19/refseq'");
 	}
 
 }


### PR DESCRIPTION
Hi, please have a look at this. This uses `argparse4j` which has a somewhat nicer API for command line parsing and also provides (IMO) better command line help.

```
$ java -jar jannovar-cli.jar --help
usage: jannovar [-h] [--verbose] [--very-verbose]
                {download,db-list,annotate-pos,annotate-vcf} ...

positional arguments:
  {download,db-list,annotate-pos,annotate-vcf}
    download             Download database
    db-list              List transcript databases to download
    annotate-pos         Annotate predicted molecular inpact with Jannovar
    annotate-vcf         Annoate a VCF file with Jannovar

optional arguments:
  -h, --help             show this help message and exit
  --verbose              Enable verbose logging
  --very-verbose         Enable very verbose logging
```

```
$ java -jar jannovar-cli.jar download --help
usage: jannovar download [-h] [--data-source-list DATA_SOURCE_LIST]
                [--data-dir DATA_DIR] -d DATASOURCE [--proxy PROXY]
                [--http-proxy HTTP_PROXY] [--https-proxy HTTPS_PROXY]
                [--ftp-proxy FTP_PROXY]

Download  database   from   ENSEMBL/UCSC/RefSeq   etc.   By   default,  the
environment variables  http_proxy,  https_proxy,  ftp_proxy  and  the upper
case variants are used if set.

optional arguments:
  -h, --help             show this help message and exit
  --data-source-list DATA_SOURCE_LIST
                         Path to INI file with data source list
  --data-dir DATA_DIR    target  folder  for   downloaded   and  serialized
                         files, defaults to "data"
  -d DATASOURCE, --datasource DATASOURCE
                         Name of the data source to download, get with 'db-
                         list' command

Proxy settings:
  Proxy settings, should have the format <proto>://<host>[:port]/

  --proxy PROXY          Overall proxy, overridden  by  other more specific
                         ones
  --http-proxy HTTP_PROXY
                         HTTP proxy
  --https-proxy HTTPS_PROXY
                         HTTPS proxy
  --ftp-proxy FTP_PROXY  FTP proxy to use

Use this  command  to  download  a  transcript  database,  e.g.,  using '-d
hg19/refseq'
```