### PR TITLE
Hotfix/genotype no call fix

### DIFF
--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/mendel/Genotype.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/mendel/Genotype.java
@@ -71,7 +71,9 @@ public class Genotype {
 	public boolean isHet() {
 		if (!isDiploid())
 			return false; // only diploid genotypes cann be heterozygous
-		return !alleleNumbers.get(0).equals(alleleNumbers.get(1)) && !alleleNumbers.stream().allMatch(n -> n == NO_CALL);
+		if (isNotObserved())
+			return false; // we want to have at least one observed call
+		return !alleleNumbers.get(0).equals(alleleNumbers.get(1));
 
 	}
 
@@ -82,8 +84,9 @@ public class Genotype {
 	public boolean isHomRef() {
 		if (alleleNumbers.isEmpty())
 			return false; // empty calls are nothing
-		return alleleNumbers.stream().allMatch(x -> x == REF_CALL || x == NO_CALL)
-				&& !alleleNumbers.stream().allMatch(x -> x == NO_CALL);
+		if (isNotObserved())
+			return false; // we want to have at least one observed call
+		return alleleNumbers.stream().allMatch(x -> x == REF_CALL || x == NO_CALL);
 	}
 
 	/**
@@ -92,14 +95,16 @@ public class Genotype {
 	public boolean isHomAlt() {
 		if (alleleNumbers.isEmpty())
 			return false; // empty calls are nothing
-		boolean notRefNotNoCall = alleleNumbers.stream().allMatch(x -> x != REF_CALL)
-				&& !alleleNumbers.stream().allMatch(n -> n == NO_CALL);
-		if (!notRefNotNoCall)
+		if (isNotObserved())
+			return false; // we want to have at least one observed call
+		
+		boolean noRefCall = alleleNumbers.stream().noneMatch(x -> x == REF_CALL);
+		if (!noRefCall)
 			return false;
 
-		List<Integer> alts = alleleNumbers.stream().filter(n -> n != NO_CALL).collect(Collectors.toList());
-		Integer alt = alts.get(0);
-		for (Integer otherAlt : alts) {
+		List<Integer> calledAlts = alleleNumbers.stream().filter(n -> n != NO_CALL).collect(Collectors.toList());
+		Integer alt = calledAlts.get(0);
+		for (Integer otherAlt : calledAlts) {
 			if (!alt.equals(otherAlt))
 				return false;
 		}
@@ -112,7 +117,7 @@ public class Genotype {
 	public boolean isNotObserved() {
 		return alleleNumbers.stream().allMatch(n -> n == NO_CALL);
 	}
-
+	
 	@Override
 	public String toString() {
 		return "Genotype [alleleNumbers=" + alleleNumbers + "]";

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/mendel/Genotype.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/mendel/Genotype.java
@@ -14,6 +14,11 @@ import de.charite.compbio.jannovar.Immutable;
  * Genotypes are represented by lists of integers identifying alleles from a {@link GenotypeCalls}. By convention, the
  * reference allele is represented by the integer <code>0</code>. <code>-1</code> encodes no-call.
  * 
+ * Jannovar will define the zygosity in a very soft way. We do not want to throw too much things away. If all
+ * {@link Genotype} are no-calls then teh gebnotype is not observed. But if we have one {@link Genotype} called and
+ * another is a no-call (e.g 0/.) we will consider fo the no-call all possibilities. So it can be het or homRef. This
+ * behaviour is different to HTSJDK VariantContexed where they have a additional mixed class for such genotypes.
+ * 
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  * @author <a href="mailto:j.jacobsen@qmul.ac.uk">Jules Jacobsen</a>
  * @author <a href="mailto:max.schubach@charite.de">Max Schubach</a>
@@ -97,7 +102,7 @@ public class Genotype {
 			return false; // empty calls are nothing
 		if (isNotObserved())
 			return false; // we want to have at least one observed call
-		
+
 		boolean noRefCall = alleleNumbers.stream().noneMatch(x -> x == REF_CALL);
 		if (!noRefCall)
 			return false;
@@ -117,7 +122,7 @@ public class Genotype {
 	public boolean isNotObserved() {
 		return alleleNumbers.stream().allMatch(n -> n == NO_CALL);
 	}
-	
+
 	@Override
 	public String toString() {
 		return "Genotype [alleleNumbers=" + alleleNumbers + "]";

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/GenotypeTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/GenotypeTest.java
@@ -1,0 +1,215 @@
+package de.charite.compbio.jannovar.mendel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:j.jacobsen@qmul.ac.uk">Jules Jacobsen</a>
+ * @author <a href="mailto:max.schubach@charite.de">Max Schubach</a>
+ */
+public class GenotypeTest {
+
+	@Test
+	public void emptyAlleles() {
+		Genotype genotype = new Genotype(Collections.emptyList());
+		assertEquals(0, genotype.getPloidy());
+		assertFalse(genotype.isMonoploid());
+		assertFalse(genotype.isDiploid());
+		assertFalse(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+		assertEquals(Collections.emptyList(), genotype.getAlleleNumbers());
+	}
+
+	@Test
+	public void testMonoploidRef() {
+		Genotype genotype = new Genotype(Collections.singletonList(0));
+		assertEquals(1, genotype.getPloidy());
+		assertTrue(genotype.isMonoploid());
+		assertFalse(genotype.isDiploid());
+		assertFalse(genotype.isHet());
+		// TODO: Should this really true? Its a monoploid.
+		assertTrue(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testMonoploidAlt() {
+		Genotype genotype = new Genotype(Collections.singletonList(1));
+		assertEquals(1, genotype.getPloidy());
+		assertTrue(genotype.isMonoploid());
+		assertFalse(genotype.isDiploid());
+		assertFalse(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		// TODO: Should this really true? Its a monoploid.
+		assertTrue(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testMonoploidNoCall() {
+		Genotype genotype = new Genotype(Collections.singletonList(-1));
+		assertEquals(1, genotype.getPloidy());
+		assertTrue(genotype.isNotObserved());
+		// TODO: Should an unobserved monoploid really be classed as a monoploid?
+		assertTrue(genotype.isMonoploid());
+		assertFalse(genotype.isDiploid());
+		assertFalse(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidHomRef() {
+		Genotype genotype = new Genotype(Arrays.asList(0, 0));
+		assertEquals(2, genotype.getPloidy());
+		assertFalse(genotype.isHet());
+		assertTrue(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidNoCallHetRef() {
+		Genotype genotype = new Genotype(Arrays.asList(-1, 0));
+		assertEquals(2, genotype.getPloidy());
+		// TODO: Should a diploid with an unobserved allele really be classed as a diploid?
+		assertFalse(genotype.isMonoploid());
+		assertTrue(genotype.isDiploid());
+
+		assertTrue(genotype.isHet());
+		assertTrue(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidNoCallHetAlt() {
+		Genotype genotype = new Genotype(Arrays.asList(0, -1));
+		assertEquals(2, genotype.getPloidy());
+		// TODO: Should a diploid with an unobserved allele really be classed as a diploid?
+		assertFalse(genotype.isMonoploid());
+		assertTrue(genotype.isDiploid());
+
+		assertTrue(genotype.isHet());
+		assertTrue(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidNoCallHom() {
+		Genotype genotype = new Genotype(Arrays.asList(-1, -1));
+		assertEquals(2, genotype.getPloidy());
+		// TODO: Should a diploid with an unobserved allele really be classed as a diploid?
+		assertFalse(genotype.isMonoploid());
+		assertTrue(genotype.isDiploid());
+
+		assertFalse(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidNoCallHetVar() {
+		Genotype genotype = new Genotype(Arrays.asList(1, -1));
+		assertEquals(2, genotype.getPloidy());
+		assertTrue(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertTrue(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidNoCallHetAltRef() {
+		Genotype genotype = new Genotype(Arrays.asList(-1, 1));
+		assertEquals(2, genotype.getPloidy());
+		assertTrue(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertTrue(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidHet() {
+		Genotype genotype = new Genotype(Arrays.asList(0, 1));
+		assertEquals(2, genotype.getPloidy());
+		assertTrue(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidHomAlt() {
+		Genotype genotype = new Genotype(Arrays.asList(1, 1));
+		assertEquals(2, genotype.getPloidy());
+		assertFalse(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertTrue(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidMultiSampleHetRef() {
+		Genotype genotype = new Genotype(Arrays.asList(0, 2));
+		assertEquals(2, genotype.getPloidy());
+		assertTrue(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+	
+	@Test
+	public void testDiploidMultiSampleHetUnk() {
+		Genotype genotype = new Genotype(Arrays.asList(-1, 2));
+		assertEquals(2, genotype.getPloidy());
+		assertTrue(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertTrue(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testDiploidMultiSampleHomAlt() {
+		Genotype genotype = new Genotype(Arrays.asList(2, 2));
+		assertEquals(2, genotype.getPloidy());
+		assertFalse(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertTrue(genotype.isHomAlt());
+	}
+
+	/**
+	 * Previously this would fail in case of multi-sample genotypes.
+	 */
+	@Test
+	public void testDiploidMultiSampleHetVar() {
+		Genotype genotype = new Genotype(Arrays.asList(1, 2));
+		assertEquals(2, genotype.getPloidy());
+		assertTrue(genotype.isHet());
+		assertFalse(genotype.isHomRef());
+		assertFalse(genotype.isHomAlt());
+	}
+
+	@Test
+	public void testHashCode() {
+		Map<Genotype, String> map = new HashMap<>();
+		map.put(new Genotype(Arrays.asList(1, 2)), "ONE");
+		map.put(new Genotype(Arrays.asList(1, 2)), "TWO");
+		map.put(new Genotype(Arrays.asList(1, 1)), "THREE");
+
+		Map<Genotype, String> expected = new HashMap<>();
+		expected.put(new Genotype(Arrays.asList(1, 2)), "TWO");
+		expected.put(new Genotype(Arrays.asList(1, 1)), "THREE");
+		assertEquals(expected, map);
+	}
+
+	@Test
+	public void testEquals() {
+		Genotype one = new Genotype(Arrays.asList(1, 2));
+		Genotype two = new Genotype(Arrays.asList(1, 2));
+		Genotype three = new Genotype(Arrays.asList(1, 1));
+		Genotype four = new Genotype(Collections.singletonList(1));
+		assertTrue(one.equals(two));
+		assertFalse(one.equals(three));
+		assertFalse(one.equals(four));
+	}
+}

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/GenotypeTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/GenotypeTest.java
@@ -160,13 +160,22 @@ public class GenotypeTest {
 	}
 	
 	@Test
-	public void testDiploidMultiSampleHetUnk() {
+	public void testDiploidMultiSampleMixed1() {
 		Genotype genotype = new Genotype(Arrays.asList(-1, 2));
 		assertEquals(2, genotype.getPloidy());
 		assertTrue(genotype.isHet());
 		assertFalse(genotype.isHomRef());
 		assertTrue(genotype.isHomAlt());
 	}
+	
+    @Test
+    public void testDiploidMultiSampleMixed2() {
+	Genotype genotype = new Genotype(Arrays.asList(2, -1));
+	assertEquals(2, genotype.getPloidy());
+	assertTrue(genotype.isHet());
+	assertFalse(genotype.isHomRef());
+	assertTrue(genotype.isHomAlt());
+    }
 
 	@Test
 	public void testDiploidMultiSampleHomAlt() {

--- a/manual/inheritance.rst
+++ b/manual/inheritance.rst
@@ -133,3 +133,11 @@ Annotating AD Variants
 
 The variants at ``chr1:879317`` and ``chr1:879482`` match the autosomal dominant mode of inheritance from the father.
 The remaining variants do not match this mode of inheritance.
+
+
+-------------------------------
+No-calls and Mixed genotypes
+-------------------------------
+
+We implemented the filter that we might loose specificity but not some sensitibvity.Therfore a genotype call of ``./1`` or ``1/.`` can be ``HET`` or ``HOM_ALT``. ``0/.`` or ``./0`` are ``HET`` or ``HOM_REF``. A no-call of ``./.`` is ``NO_CALL`` and will be used only as a wildcard in multi-vcfs but at least one called correct genotype must be observed. For more information see :ref:`ped_filters`.
+


### PR DESCRIPTION
I think this is the correct one. jannovar should keep the "uncertain" variants and should not remove them.

`1/2` is now het