### PR TITLE
Adjusting behaviour of reference and transcript chars being unequal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## develop
 
+### jannovar-cli
+
+* Printing warnings next to the annotations in `annotate-pos`
+
+### jannovar-core
+
+* Making the behaviour of overriding transcripts configurable at least in the code, using default to not do this any more
+* Adding `WARNING_REF_DOES_NOT_MATCH_TRANSCRIPT` to `AnnotationMessage`
+* Properly pushing through warnings from the annotators into the returned `VariantAnnotation` object
+
 ### jannovar-htsjdk
 
-* Fixing bug with problems of unmodifieable Attributes (error annotation).
+* Fixing bug with problems of unmodifiable Attributes (error annotation).
 
 ## v0.20
 

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_pos/AnnotatePositionCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_pos/AnnotatePositionCommand.java
@@ -57,7 +57,7 @@ public class AnnotatePositionCommand extends JannovarAnnotationCommand {
 		deserializeTranscriptDefinitionFile(options.getDatabaseFilePath());
 
 		final VariantAnnotator annotator = new VariantAnnotator(refDict, chromosomeMap, new AnnotationBuilderOptions());
-		System.out.println("#change\teffect\thgvs_annotation");
+		System.out.println("#change\teffect\thgvs_annotation\tmessages");
 		for (String chromosomalChange : options.getGenomicChanges()) {
 			// Parse the chromosomal change string into a GenomeChange object.
 			final GenomeVariant genomeChange = parseGenomeChange(chromosomalChange);
@@ -75,6 +75,7 @@ public class AnnotatePositionCommand extends JannovarAnnotationCommand {
 			// Obtain first or all functional annotation(s) and effect(s).
 			final String annotation;
 			final String effect;
+			final String messages;
 			VariantAnnotationsTextGenerator textGenerator;
 			if (options.isShowAll())
 				textGenerator = new AllAnnotationListTextGenerator(annoList, 0, 1);
@@ -83,8 +84,9 @@ public class AnnotatePositionCommand extends JannovarAnnotationCommand {
 			annotation = textGenerator.buildHGVSText(
 					options.isUseThreeLetterAminoAcidCode() ? AminoAcidCode.THREE_LETTER : AminoAcidCode.ONE_LETTER);
 			effect = textGenerator.buildEffectText();
-
-			System.out.println(String.format("%s\t%s\t%s", chromosomalChange.toString(), effect, annotation));
+			messages = textGenerator.buildMessages();
+			
+			System.out.println(String.format("%s\t%s\t%s\t%s", chromosomalChange.toString(), effect, annotation, messages));
 		}
 	}
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationMessage.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/AnnotationMessage.java
@@ -12,6 +12,12 @@ public enum AnnotationMessage {
 	/** (E2) The variant's genomic coordinate is greater than chromosome's length. */
 	ERROR_OUT_OF_CHROMOSOME_RANGE,
 	/**
+	 * (Additional warning) This means that the "REF" field in the input VCF file does not match the reference genome. This warning
+	 * may indicate a conflict between input data and data from reference genome (for instance is the input VCF was
+	 * aligned to a different reference genome).
+	 */
+	WARNING_REF_DOES_NOT_MATCH_TRANSCRIPT,
+	/**
 	 * (W1) This means that the "REF" field in the input VCF file does not match the reference genome. This warning
 	 * may indicate a conflict between input data and data from reference genome (for instance is the input VCF was
 	 * aligned to a different reference genome).

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotationsTextGenerator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotationsTextGenerator.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.annotation;
 
+import java.util.stream.Collectors;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
@@ -78,6 +80,18 @@ public abstract class VariantAnnotationsTextGenerator {
 			builder.append(anno.getSymbolAndAnnotation(code));
 		}
 		return builder.toString();
+	}
+
+	/**
+	 * @return Messages
+	 */
+	public String buildMessages() {
+		return Joiner.on(';').join(getAnnotations().stream().map(a -> Joiner.on(',').join(a.getMessages())).map(s -> {
+			if (s.isEmpty())
+				return ".";
+			else
+				return s;
+		}).collect(Collectors.toList()));
 	}
 
 	/**

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
@@ -182,7 +182,8 @@ abstract class AnnotationBuilder {
 			else
 				varTypes.add(VariantEffect.NON_CODING_TRANSCRIPT_INTRON_VARIANT);
 		}
-		return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(), null);
+		return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(), null,
+				messages);
 	}
 
 	/** @return intronic anotation */
@@ -220,7 +221,7 @@ abstract class AnnotationBuilder {
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT, VariantEffect.SPLICE_REGION_VARIANT)).isEmpty())
 			proteinChange = ProteinMiscChange.build(true, ProteinMiscChangeType.DIFFICULT_TO_PREDICT);
 		return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(),
-				proteinChange);
+				proteinChange, messages);
 	}
 
 	/**
@@ -310,28 +311,28 @@ abstract class AnnotationBuilder {
 			GenomePosition lPos = pos.shifted(-1);
 			if (so.liesInUpstreamRegion(lPos))
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.UPSTREAM_GENE_VARIANT), null,
-						null, null, null);
+						null, null, null, messages);
 			else
 				// so.liesInDownstreamRegion(pos))
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.DOWNSTREAM_GENE_VARIANT), null,
-						null, null, null);
+						null, null, null, messages);
 		} else {
 			// Non-empty interval, at least one reference base changed/deleted.
 			GenomeInterval changeInterval = change.getGenomeInterval();
 			if (so.overlapsWithUpstreamRegion(changeInterval))
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.UPSTREAM_GENE_VARIANT), null,
-						null, null, null);
+						null, null, null, messages);
 			else
 				// so.overlapsWithDownstreamRegion(changeInterval)
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.DOWNSTREAM_GENE_VARIANT), null,
-						null, null, null);
+						null, null, null, messages);
 		}
 	}
 
 	/** @return intergenic anotation */
 	protected Annotation buildIntergenicAnnotation() {
 		return new Annotation(transcript, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT), null, null, null,
-				null);
+				null, messages);
 	}
 
 	/**

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilderOptions.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilderOptions.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
+import de.charite.compbio.jannovar.reference.GenomeVariant;
+
 /**
  * Configuration for the {@link AnnotationBuilder} subclasses.
  *
@@ -12,12 +14,21 @@ public class AnnotationBuilderOptions {
 	 */
 	private final boolean nt3PrimeShifting;
 
+	/**
+	 * whether or not to override transcript sequence with user input, that is
+	 * the sequence in the {@link GenomeVariant} (default is
+	 * <code>false</code>).
+	 */
+	private final boolean overrideTxSeqWithGenomeVariantRef;
+
 	public AnnotationBuilderOptions() {
 		this.nt3PrimeShifting = true;
+		this.overrideTxSeqWithGenomeVariantRef = false;
 	}
 
-	public AnnotationBuilderOptions(boolean nt3PrimeShifting) {
+	public AnnotationBuilderOptions(boolean nt3PrimeShifting, boolean overrideTxSeqWithGenomeVariantRef) {
 		this.nt3PrimeShifting = nt3PrimeShifting;
+		this.overrideTxSeqWithGenomeVariantRef = overrideTxSeqWithGenomeVariantRef;
 	}
 
 	/**
@@ -27,4 +38,13 @@ public class AnnotationBuilderOptions {
 	public boolean isNt3PrimeShifting() {
 		return nt3PrimeShifting;
 	}
+
+	/**
+	 * @return whether or not to override transcript sequence with user input,
+	 *         that is the sequence in the {@link GenomeVariant}
+	 */
+	public boolean isOverrideTxSeqWithGenomeVariantRef() {
+		return overrideTxSeqWithGenomeVariantRef;
+	}
+
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
@@ -84,12 +84,14 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 
 	private Annotation buildFeatureAblationAnnotation() {
 		return new Annotation(transcript, change, ImmutableList.of(VariantEffect.TRANSCRIPT_ABLATION), locAnno,
-				getGenomicNTChange(), getCDSNTChange(), ProteinMiscChange.build(true, ProteinMiscChangeType.NO_PROTEIN));
+				getGenomicNTChange(), getCDSNTChange(), ProteinMiscChange.build(true, ProteinMiscChangeType.NO_PROTEIN),
+				messages);
 	}
 
 	private Annotation buildStartLossAnnotation() {
 		return new Annotation(transcript, change, ImmutableList.of(VariantEffect.START_LOST), locAnno,
-				getGenomicNTChange(), getCDSNTChange(), ProteinMiscChange.build(true, ProteinMiscChangeType.NO_PROTEIN));
+				getGenomicNTChange(), getCDSNTChange(), ProteinMiscChange.build(true, ProteinMiscChangeType.NO_PROTEIN),
+				messages);
 	}
 
 	/**
@@ -158,7 +160,7 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 				handleFrameShiftCase();
 
 			return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(),
-					proteinChange);
+					proteinChange, messages);
 		}
 
 		private void handleNonFrameShiftCase() {
@@ -190,11 +192,11 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 				if (aaChange.getPos() == aaChange.getLastPos()) {
 					if (aaChange.getAlt().length() > 0)
 						proteinChange = ProteinIndel.buildWithSeqDescription(true, wtAAFirst, aaChange.getPos(),
-								wtAAFirst, aaChange.getPos(), new ProteinSeqDescription(), new ProteinSeqDescription(
-										aaChange.getAlt()));
+								wtAAFirst, aaChange.getPos(), new ProteinSeqDescription(),
+								new ProteinSeqDescription(aaChange.getAlt()));
 					else
-						proteinChange = ProteinDeletion.buildWithSequence(true, wtAAFirst, aaChange.getPos(),
-								wtAAFirst, aaChange.getPos(), aaChange.getAlt());
+						proteinChange = ProteinDeletion.buildWithSequence(true, wtAAFirst, aaChange.getPos(), wtAAFirst,
+								aaChange.getPos(), aaChange.getAlt());
 				} else {
 					if (aaChange.getAlt().length() > 0)
 						proteinChange = ProteinIndel.buildWithSeqDescription(true, wtAAFirst, aaChange.getPos(),

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
@@ -111,19 +111,19 @@ public final class InsertionAnnotationBuilder extends AnnotationBuilder {
 			NucleotidePointLocationBuilder posBuilder = new NucleotidePointLocationBuilder(transcript);
 			if (change.getAlt().length() == 1) {
 				try {
-					final NucleotideRange range = new NucleotideRange(posBuilder.getNucleotidePointLocation(projector
-							.transcriptToGenomePos(txPos.shifted(-1))), posBuilder.getNucleotidePointLocation(projector
-							.transcriptToGenomePos(txPos.shifted(-1))));
+					final NucleotideRange range = new NucleotideRange(
+							posBuilder.getNucleotidePointLocation(projector.transcriptToGenomePos(txPos.shifted(-1))),
+							posBuilder.getNucleotidePointLocation(projector.transcriptToGenomePos(txPos.shifted(-1))));
 					return new NucleotideDuplication(false, range, new NucleotideSeqDescription());
 				} catch (ProjectionException e) {
 					throw new RuntimeException("Bug: positions should be valid here", e);
 				}
 			} else {
 				try {
-					final NucleotidePointLocation firstPos = posBuilder.getNucleotidePointLocation(projector
-							.transcriptToGenomePos(txPos.shifted(-change.getAlt().length())));
-					final NucleotidePointLocation lastPos = posBuilder.getNucleotidePointLocation(projector
-							.transcriptToGenomePos(txPos.shifted(-1)));
+					final NucleotidePointLocation firstPos = posBuilder.getNucleotidePointLocation(
+							projector.transcriptToGenomePos(txPos.shifted(-change.getAlt().length())));
+					final NucleotidePointLocation lastPos = posBuilder
+							.getNucleotidePointLocation(projector.transcriptToGenomePos(txPos.shifted(-1)));
 					final NucleotideRange range = new NucleotideRange(firstPos, lastPos);
 					return new NucleotideDuplication(false, range, new NucleotideSeqDescription());
 				} catch (ProjectionException e) {
@@ -220,7 +220,7 @@ public final class InsertionAnnotationBuilder extends AnnotationBuilder {
 			}
 
 			return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(),
-					proteinChange);
+					proteinChange, messages);
 		}
 
 		private void handleFrameShiftCase() {
@@ -341,9 +341,8 @@ public final class InsertionAnnotationBuilder extends AnnotationBuilder {
 				varTypes.add(VariantEffect.STOP_LOST);
 			} else {
 				// varAA contains no stop codon
-				proteinChange = ProteinExtension.buildWithoutTerminal(true,
-						toString(wtAASeq.charAt(aaChange.getPos())), aaChange.getPos(),
-						toString(varAASeq.charAt(aaChange.getPos())));
+				proteinChange = ProteinExtension.buildWithoutTerminal(true, toString(wtAASeq.charAt(aaChange.getPos())),
+						aaChange.getPos(), toString(varAASeq.charAt(aaChange.getPos())));
 				varTypes.add(VariantEffect.STOP_LOST);
 			}
 		}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
@@ -95,7 +95,7 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 		// if this is not the case.
 		if (txPos.getPos() >= transcript.getSequence().length()
 				|| !transcript.getSequence().substring(txPos.getPos(), txPos.getPos() + 1).equals(change.getRef()))
-			messages.add(AnnotationMessage.WARNING_REF_DOES_NOT_MATCH_GENOME);
+			messages.add(AnnotationMessage.WARNING_REF_DOES_NOT_MATCH_TRANSCRIPT);
 
 		// Compute the frame shift and codon start position.
 		int frameShift = cdsPos.getPos() % 3;
@@ -112,8 +112,9 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 					getCDSNTChange(), ProteinMiscChange.build(true, ProteinMiscChangeType.DIFFICULT_TO_PREDICT),
 					ImmutableList.of(AnnotationMessage.ERROR_PROBLEM_DURING_ANNOTATION));
 		}
-		String wtCodon = TranscriptSequenceDecorator.codonWithUpdatedBase(transcriptCodon, frameShift,
-				change.getRef().charAt(0));
+		String wtCodon = transcriptCodon;
+		if (options.isOverrideTxSeqWithGenomeVariantRef())
+			TranscriptSequenceDecorator.codonWithUpdatedBase(wtCodon, frameShift, change.getRef().charAt(0));
 		String varCodon = TranscriptSequenceDecorator.codonWithUpdatedBase(transcriptCodon, frameShift,
 				change.getAlt().charAt(0));
 
@@ -159,7 +160,7 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 
 		// Build the resulting Annotation.
 		return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(),
-				proteinChange);
+				proteinChange, messages);
 	}
 
 	@Override

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/StructuralVariantAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/StructuralVariantAnnotationBuilder.java
@@ -76,29 +76,29 @@ public final class StructuralVariantAnnotationBuilder {
 		if (ref.length() == alt.length() && ref.equals(altRC.toString())) { // SV inversion
 			if (transcript == null) {
 				return new Annotation(null, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT,
-						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null, messages);
+						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
 			} else {
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT), annoLoc,
-						ntChange, null, null, messages);
+						ntChange, null, null);
 
 			}
 		} else if (ref.length() == 0) { // SV insertion
 			// if transcript is null it is intergenic
 			if (transcript == null) {
 				return new Annotation(null, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT,
-						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null, messages);
+						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
 			} else {
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT), annoLoc,
-						ntChange, null, null, messages);
+						ntChange, null, null);
 			}
 		} else if (alt.length() == 0) { // SV deletion
 			// if tm is null it is intergenic
 			if (transcript == null) {
 				return new Annotation(null, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT,
-						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null, messages);
+						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
 			} else {
 				return new Annotation(this.transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT),
-						annoLoc, ntChange, null, null, messages);
+						annoLoc, ntChange, null, null);
 			}
 		} else { // SV substitution
 			if (transcript == null) {
@@ -106,7 +106,7 @@ public final class StructuralVariantAnnotationBuilder {
 						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
 			} else {
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT), annoLoc,
-						ntChange, null, null, messages);
+						ntChange, null, null);
 			}
 		}
 	}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/StructuralVariantAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/StructuralVariantAnnotationBuilder.java
@@ -76,29 +76,29 @@ public final class StructuralVariantAnnotationBuilder {
 		if (ref.length() == alt.length() && ref.equals(altRC.toString())) { // SV inversion
 			if (transcript == null) {
 				return new Annotation(null, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT,
-						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
+						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null, messages);
 			} else {
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT), annoLoc,
-						ntChange, null, null);
+						ntChange, null, null, messages);
 
 			}
 		} else if (ref.length() == 0) { // SV insertion
 			// if transcript is null it is intergenic
 			if (transcript == null) {
 				return new Annotation(null, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT,
-						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
+						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null, messages);
 			} else {
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT), annoLoc,
-						ntChange, null, null);
+						ntChange, null, null, messages);
 			}
 		} else if (alt.length() == 0) { // SV deletion
 			// if tm is null it is intergenic
 			if (transcript == null) {
 				return new Annotation(null, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT,
-						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
+						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null, messages);
 			} else {
 				return new Annotation(this.transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT),
-						annoLoc, ntChange, null, null);
+						annoLoc, ntChange, null, null, messages);
 			}
 		} else { // SV substitution
 			if (transcript == null) {
@@ -106,7 +106,7 @@ public final class StructuralVariantAnnotationBuilder {
 						VariantEffect.STRUCTURAL_VARIANT), null, ntChange, null, null);
 			} else {
 				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.STRUCTURAL_VARIANT), annoLoc,
-						ntChange, null, null);
+						ntChange, null, null, messages);
 			}
 		}
 	}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
@@ -154,7 +154,7 @@ public class RefSeqParser implements TranscriptParser {
 				assert missingSequence.contains(builder.getAccession());
 				missingSequence.remove(builder.getAccession());
 
-				builder.setAccession(builder.getSequence());
+				builder.setAccession(accession);
 				builder.setSequence(record.getSequence());
 				LOGGER.debug("Found sequence for transcript {}", new Object[] { builder.getAccession() });
 			}

--- a/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantContextAnnotator.java
+++ b/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantContextAnnotator.java
@@ -148,7 +148,7 @@ public final class VariantContextAnnotator {
 		this.chromosomeMap = chromosomeMap;
 		this.options = options;
 		this.annotator = new VariantAnnotator(refDict, chromosomeMap,
-				new AnnotationBuilderOptions(options.nt3PrimeShifting));
+				new AnnotationBuilderOptions(options.nt3PrimeShifting, false));
 	}
 
 	/**


### PR DESCRIPTION
### jannovar-cli

* Printing warnings next to the annotations in `annotate-pos`

### jannovar-core

* Making the behaviour of overriding transcripts configurable at least in the code, using default to not do this any more
* Adding `WARNING_REF_DOES_NOT_MATCH_TRANSCRIPT` to `AnnotationMessage`
* Properly pushing through warnings from the annotators into the returned `VariantAnnotation` object

closes #304