### PR TITLE
Pedigree files are now more compatible to the PLINK format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Making the behaviour of overriding transcripts configurable at least in the code, using default to not do this any more
 * Adding `WARNING_REF_DOES_NOT_MATCH_TRANSCRIPT` to `AnnotationMessage`
 * Properly pushing through warnings from the annotators into the returned `VariantAnnotation` object
+* Pedigree files are now more compatible to the PLINK format
+	* whitespace separated instead of tab separated (read only, written as TSV)
+	* interpreting any value not in {1, 2} to be "unknown" sex instead (coded as 0) of throwing
 
 ### jannovar-htsjdk
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/pedigree/PedFileReader.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/pedigree/PedFileReader.java
@@ -101,12 +101,7 @@ public final class PedFileReader {
 	 */
 	private static PedPerson readIndividual(String line) throws PedParseException {
 		try {
-			Iterator<String> it = Splitter.on('\t').split(line.trim()).iterator();
-
-			/*
-			 * public PedPerson(String pedigree, String name, String father, String mother, Sex sex, Disease disease,
-			 * Collection<String> extraFields) {
-			 */
+			Iterator<String> it = Splitter.onPattern("\\s+").split(line.trim()).iterator();
 
 			// parse out core fields
 			String pedigree = it.next();

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/pedigree/Sex.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/pedigree/Sex.java
@@ -37,14 +37,12 @@ public enum Sex {
 	 *             if <code>s</code> was not equal to <code>"0"</code>, <code>"1"</code>, or <code>"2"</code>.
 	 */
 	public static Sex toSex(String s) throws PedParseException {
-		if (s.equals("0"))
-			return UNKNOWN;
-		else if (s.equals("1"))
+		if (s.equals("1"))
 			return MALE;
 		else if (s.equals("2"))
 			return FEMALE;
 		else
-			throw new PedParseException("Invalid PED sex value: " + s);
+			return UNKNOWN;
 	}
 
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/pedigree/SexTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/pedigree/SexTest.java
@@ -10,7 +10,7 @@ import de.charite.compbio.jannovar.pedigree.Sex;
 public class SexTest {
 
 	@Test
-	public void testToInt() {
+	public void testToPlink() {
 		assertEquals(Sex.UNKNOWN.toInt(), 0);
 		assertEquals(Sex.MALE.toInt(), 1);
 		assertEquals(Sex.FEMALE.toInt(), 2);
@@ -19,13 +19,10 @@ public class SexTest {
 	@Test
 	public void toSex() throws PedParseException {
 		assertEquals(Sex.toSex("0"), Sex.UNKNOWN);
+		assertEquals(Sex.toSex("3"), Sex.UNKNOWN);
+		assertEquals(Sex.toSex("anything-really"), Sex.UNKNOWN);
 		assertEquals(Sex.toSex("1"), Sex.MALE);
 		assertEquals(Sex.toSex("2"), Sex.FEMALE);
-	}
-
-	@Test(expected = PedParseException.class)
-	public void toSexThrows() throws PedParseException {
-		assertEquals(Sex.toSex("3"), Sex.UNKNOWN);
 	}
 
 }


### PR DESCRIPTION
* whitespace separated instead of tab separated (read only, written as TSV)
* interpreting any value not in {1, 2} to be "unknown" sex instead (coded as 0) of throwing

@visze @pnrobinson this should address Nick's question and make Jannovar accept the "full" PLINK format. IMHO, PLINK should have enforced TSV as it allows for easier representation of empty columns. Now, all extended columns have to code for an "empty" value such as `'.'`. Well, could be worse.