### PR TITLE
bugfix CompHet without parents in pedigree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   Filtered genotypes will be passed into the inheritance filter as no-call.
 * Adding annotation with ClinVar
 * Printing warnings next to the annotations in `annotate-pos`
+* AR inheritance annotation of two siblings bugfix (no parents avaiable in comp.het mode) #314
 
 ### jannovar-filter
 

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/MendelianCompatibilityCheckerARSiblingsTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/MendelianCompatibilityCheckerARSiblingsTest.java
@@ -1,0 +1,170 @@
+package de.charite.compbio.jannovar.mendel;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import de.charite.compbio.jannovar.pedigree.Disease;
+import de.charite.compbio.jannovar.pedigree.PedFileContents;
+import de.charite.compbio.jannovar.pedigree.PedPerson;
+import de.charite.compbio.jannovar.pedigree.Pedigree;
+import de.charite.compbio.jannovar.pedigree.Sex;
+
+public class MendelianCompatibilityCheckerARSiblingsTest extends MendelianCompatibilityCheckerTestBase {
+
+	MendelianInheritanceChecker checker;
+	List<GenotypeCalls> gcList;
+	ImmutableMap<ModeOfInheritance, ImmutableList<GenotypeCalls>> result;
+
+	@Before
+	public void setUp() throws Exception {
+		ImmutableList.Builder<PedPerson> individuals = new ImmutableList.Builder<PedPerson>();
+		individuals.add(new PedPerson("ped", "I.1", "0", "0", Sex.MALE, Disease.AFFECTED)); // child 1
+		individuals.add(new PedPerson("ped", "I.2", "0", "0", Sex.FEMALE, Disease.AFFECTED)); // child 2
+		PedFileContents pedFileContents = new PedFileContents(new ImmutableList.Builder<String>().build(),
+				individuals.build());
+		this.pedigree = new Pedigree(pedFileContents, "ped");
+
+		this.names = ImmutableList.of("I.1", "I.2");
+
+		this.checker = new MendelianInheritanceChecker(this.pedigree);
+
+		this.result = null;
+		this.gcList = null;
+	}
+
+	@Test
+	public void testSizeOfPedigree() {
+		Assert.assertEquals(2, pedigree.getMembers().size());
+	}
+	
+	@Test
+	public void testCasePositiveOneVariant1() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(HET, HET), lst(HET, HET), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCasePositiveOneVariant2() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(HET, UKN),lst(HET, UKN), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCasePositiveOneVariant3() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(UKN, HET),lst(UKN, HET), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCasePositiveOneVariant4() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(UKN, ALT),lst(UKN, ALT), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCasePositiveOneVariant5() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(ALT, ALT),lst(ALT, ALT), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCasePositiveOneVariant6() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(HET, UKN),lst(UKN, HET), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCaseNegativeOneVariant1() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(REF, REF),lst(REF, REF), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCaseNegativeOneVariant2() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(HET, REF),lst(HET, REF), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCaseNegativeOneVariant3() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(ALT, REF),lst(ALT, REF), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCaseNegativeOneVariant4() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(HET, ALT),lst(HET, ALT), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+	@Test
+	public void testCaseNegativeOneVariant5() throws IncompatiblePedigreeException {
+		gcList = getGenotypeCallsList(lst(UKN, UKN),lst(UKN, UKN), false);
+		result = checker.checkMendelianInheritance(gcList);
+
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.AUTOSOMAL_RECESSIVE).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_DOMINANT).size());
+		Assert.assertEquals(0, result.get(ModeOfInheritance.X_RECESSIVE).size());
+		Assert.assertEquals(2, result.get(ModeOfInheritance.ANY).size());
+	}
+
+	
+
+}


### PR DESCRIPTION
- add an JUNIT test with this example (two siblings, both affected, both
two het variants).
- divide collect trio candidates in parents available and no parents
available.


This closes #314