### PR TITLE
#348: TranscriptInfo -> TranscriptModel

### DIFF
--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotator.java
@@ -38,7 +38,7 @@ public final class VariantAnnotator {
 	/** {@link ReferenceDictionary} to use for genome information. */
 	final private ReferenceDictionary refDict;
 
-	/** {@link Chromosome}s with their {@link TranscriptInfo} objects. */
+	/** {@link Chromosome}s with their {@link TranscriptModel} objects. */
 	final private ImmutableMap<Integer, Chromosome> chromosomeMap;
 
 	/**

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
@@ -337,7 +337,7 @@ abstract class AnnotationBuilder {
 
 	/**
 	 * @param transcript
-	 *            {@link TranscriptInfo} to build annotation for
+	 *            {@link TranscriptModel} to build annotation for
 	 * @param change
 	 *            {@link GenomeVariant} to build annotation for
 	 * @return AnnotationLocation with location annotation
@@ -414,7 +414,7 @@ abstract class AnnotationBuilder {
 
 	/**
 	 * @param transcript
-	 *            {@link TranscriptInfo} to build annotation for
+	 *            {@link TranscriptModel} to build annotation for
 	 * @param change
 	 *            {@link GenomeVariant} to build annotation for
 	 * @return {@link NucleotideRange} describing the CDS-level position of the change (or transcript-level in the case

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
@@ -35,7 +35,7 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 
 	/**
 	 * @param transcript
-	 *            {@link TranscriptInfo} to build the annotation for
+	 *            {@link TranscriptModel} to build the annotation for
 	 * @param change
 	 *            {@link GenomeVariant} to build the annotation with
 	 * @param options

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
@@ -52,7 +52,7 @@ public final class InsertionAnnotationBuilder extends AnnotationBuilder {
 
 	/**
 	 * @param transcript
-	 *            {@link TranscriptInfo} to build the annotation for
+	 *            {@link TranscriptModel} to build the annotation for
 	 * @param change
 	 *            {@link GenomeVariant} to build the annotation with
 	 * @param options

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
@@ -42,7 +42,7 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 
 	/**
 	 * @param transcript
-	 *            {@link TranscriptInfo} to build the annotation for
+	 *            {@link TranscriptModel} to build the annotation for
 	 * @param change
 	 *            {@link GenomeVariant} to build the annotation with
 	 * @param options

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/data/JannovarData.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/data/JannovarData.java
@@ -43,14 +43,14 @@ public final class JannovarData implements Serializable {
 	 *
 	 * @param refDict
 	 *            the {@link ReferenceDictionary} to use in this object
-	 * @param transcriptInfos
+	 * @param transcriptModels
 	 *            the list of {@link TranscriptModel} objects to use in this object
 	 */
-	public JannovarData(ReferenceDictionary refDict, ImmutableList<TranscriptModel> transcriptInfos) {
+	public JannovarData(ReferenceDictionary refDict, ImmutableList<TranscriptModel> transcriptModels) {
 		this.refDict = refDict;
-		this.chromosomes = makeChromsomes(refDict, transcriptInfos);
-		this.tmByAccession = makeTMByAccession(transcriptInfos);
-		this.tmByGeneSymbol = makeTMByGeneSymbol(transcriptInfos);
+		this.chromosomes = makeChromsomes(refDict, transcriptModels);
+		this.tmByAccession = makeTMByAccession(transcriptModels);
+		this.tmByGeneSymbol = makeTMByGeneSymbol(transcriptModels);
 	}
 
 	/** @return map from chromosome ID to {@link Chromosome} */
@@ -74,53 +74,53 @@ public final class JannovarData implements Serializable {
 	}
 
 	/**
-	 * @param transcriptInfos
+	 * @param transcriptModels
 	 *            set of {@link TranscriptModel}s to build multi-mapping for
 	 * @return multi-mapping from gene symbol to {@link TranscriptModel}
 	 */
 	private static ImmutableMultimap<String, TranscriptModel> makeTMByGeneSymbol(
-			ImmutableList<TranscriptModel> transcriptInfos) {
+			ImmutableList<TranscriptModel> transcriptModels) {
 		ImmutableMultimap.Builder<String, TranscriptModel> builder = new ImmutableMultimap.Builder<String, TranscriptModel>();
-		for (TranscriptModel tm : transcriptInfos)
+		for (TranscriptModel tm : transcriptModels)
 			builder.put(tm.getGeneSymbol(), tm);
 		return builder.build();
 	}
 
 	/**
-	 * @param transcriptInfos
+	 * @param transcriptModels
 	 *            set of {@link TranscriptModel}s to build mapping for
 	 * @return mapping from gene symbol to {@link TranscriptModel}
 	 */
 	private static ImmutableMap<String, TranscriptModel> makeTMByAccession(
-			ImmutableList<TranscriptModel> transcriptInfos) {
+			ImmutableList<TranscriptModel> transcriptModels) {
 		ImmutableMap.Builder<String, TranscriptModel> builder = new ImmutableMap.Builder<String, TranscriptModel>();
-		for (TranscriptModel tm : transcriptInfos)
+		for (TranscriptModel tm : transcriptModels)
 			builder.put(tm.getAccession(), tm);
 		return builder.build();
 	}
 
 	/**
-	 * This function constructs a HashMap<Byte,Chromosome> map of Chromosome objects in which the {@link TranscriptInfo}
+	 * This function constructs a HashMap<Byte,Chromosome> map of Chromosome objects in which the {@link TranscriptModel}
 	 * objects are entered into an {@link IntervalArray} for the appropriate Chromosome.
 	 *
 	 * @param refDict
 	 *            the {@link ReferenceDictionary} to use for the construction
-	 * @param transcriptInfos
-	 *            list of {@link TranscriptInfo} objects with the transcripts of all chromosomes
+	 * @param transcriptModels
+	 *            list of {@link TranscriptModel} objects with the transcripts of all chromosomes
 	 * @return a mapping from numeric chromsome ID to {@link Chromosome} object
 	 */
 	private static ImmutableMap<Integer, Chromosome> makeChromsomes(ReferenceDictionary refDict,
-			ImmutableList<TranscriptModel> transcriptInfos) {
+			ImmutableList<TranscriptModel> transcriptModels) {
 		ImmutableMap.Builder<Integer, Chromosome> builder = new ImmutableMap.Builder<Integer, Chromosome>();
 
-		// First, factorize the TranscriptInfo objects by chromosome ID.
+		// First, factorize the TranscriptModel objects by chromosome ID.
 
 		// create hash map for this
 		HashMap<Integer, ArrayList<TranscriptModel>> transcripts = new HashMap<Integer, ArrayList<TranscriptModel>>();
 		for (Integer chrID : refDict.getContigIDToName().keySet())
 			transcripts.put(chrID, new ArrayList<TranscriptModel>());
-		// distribute TranscriptInfo lists
-		for (TranscriptModel transcript : transcriptInfos)
+		// distribute TranscriptModel lists
+		for (TranscriptModel transcript : transcriptModels)
 			transcripts.get(transcript.getChr()).add(transcript);
 
 		// Then, construct an interval tree for each chromosome and add the lists of intervals.

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/ensembl/EnsemblParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/ensembl/EnsemblParser.java
@@ -101,7 +101,7 @@ public class EnsemblParser implements TranscriptParser {
 		final String pathFASTA = PathUtil.join(basePath, getINIFileName("cdna"));
 		loadFASTA(builders, pathFASTA);
 
-		// Create final list of TranscriptInfos.
+		// Create final list of TranscriptModels.
 		ImmutableList.Builder<TranscriptModel> result = new ImmutableList.Builder<TranscriptModel>();
 		for (Entry<String, TranscriptModelBuilder> entry : builders.entrySet())
 			result.add(entry.getValue().build());

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/flatbed/FlatBEDParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/flatbed/FlatBEDParser.java
@@ -84,7 +84,7 @@ public class FlatBEDParser implements TranscriptParser {
 		LOGGER.info("Found {} transcript models from flat BED resource, {} of which had sequences", params);
 		*/
 
-		// Create final list of TranscriptInfos.
+		// Create final list of TranscriptModels.
 		ImmutableList.Builder<TranscriptModel> result = new ImmutableList.Builder<TranscriptModel>();
 		for (TranscriptModelBuilder builder : builders)
 			result.add(builder.build());

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
@@ -103,7 +103,7 @@ public class RefSeqParser implements TranscriptParser {
 		final String pathFASTA = PathUtil.join(basePath, getINIFileName("rna"));
 		loadFASTA(builders, pathFASTA);
 
-		// Create final list of TranscriptInfos.
+		// Create final list of TranscriptModels.
 		ImmutableList.Builder<TranscriptModel> result = new ImmutableList.Builder<TranscriptModel>();
 		for (Entry<String, TranscriptModelBuilder> entry : builders.entrySet())
 			result.add(entry.getValue().build());

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/ucsc/UCSCParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/ucsc/UCSCParser.java
@@ -7,7 +7,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
@@ -160,15 +159,15 @@ public class UCSCParser implements TranscriptParser {
 						new Object[] { entry.getValue().getGeneID(), entry.getValue().getAccession() });
 				entry.getValue().getAltGeneIDs().put(AltGeneIDType.ENTREZ_ID.toString(), entry.getValue().getGeneID());
 			}
-			TranscriptModel info = entry.getValue().build();
-			if (checkTranscriptInfo(info))
-				result.add(info);
+			TranscriptModel model = entry.getValue().build();
+			if (checkTranscriptModel(model))
+				result.add(model);
 		}
 		return result.build();
 	}
 
 	/**
-	 * Check whether the <code>info</code> has problems or not.
+	 * Check whether the <code>model</code> has problems or not.
 	 *
 	 * Known problems that is checked for:
 	 *
@@ -176,13 +175,13 @@ public class UCSCParser implements TranscriptParser {
 	 * <li>mRNA sequence is shorter than the sum of the exon lengths</li>
 	 * </ul>
 	 *
-	 * @param info
-	 *            {@link TranscriptInfo} to check for consistency
+	 * @param model
+	 *            {@link TranscriptModel} to check for consistency
 	 * @return <code>false</code> if known problems have been found
 	 */
-	private boolean checkTranscriptInfo(TranscriptModel info) {
-		if (info.transcriptLength() > info.getSequence().length()) {
-			LOGGER.debug("Transcript {} is indicated to be longer than its sequence. Ignoring.", info.getAccession());
+	private boolean checkTranscriptModel(TranscriptModel model) {
+		if (model.transcriptLength() > model.getSequence().length()) {
+			LOGGER.debug("Transcript {} is indicated to be longer than its sequence. Ignoring.", model.getAccession());
 			return false;
 		}
 		return true;
@@ -378,7 +377,7 @@ public class UCSCParser implements TranscriptParser {
 
 	/**
 	 * Parses the ucsc knownToLocusLink.txt file, which contains cross references from ucsc KnownGene ids to Entrez Gene
-	 * ids. The function than adds an Entrez gene id to the corresponding {@link TranscriptInfoBuilder} objects.
+	 * ids. The function than adds an Entrez gene id to the corresponding {@link TranscriptModelBuilder} objects.
 	 */
 	private void parseKnown2LocusLink(String locusPath) throws TranscriptParseException {
 		try {
@@ -471,7 +470,7 @@ public class UCSCParser implements TranscriptParser {
 	/**
 	 * Input FASTA sequences from the UCSC hg19 file {@code knownGeneMrna.txt} Note that the UCSC sequences are all in
 	 * lower case, but we convert them here to all upper case letters to simplify processing in other places of this
-	 * program. The sequences are then added to the corresponding {@link TranscriptInfoBuilder} objects.
+	 * program. The sequences are then added to the corresponding {@link TranscriptModelBuilder} objects.
 	 */
 	private void parseKnownGeneMrna(String mRNAPath) throws TranscriptParseException {
 		try {
@@ -519,7 +518,7 @@ public class UCSCParser implements TranscriptParser {
 
 	/**
 	 * Input xref information for the known genes. This method parses the ucsc xref table to get the gene symbol that
-	 * corresponds to the ucsc kgID. The information is then added to the corresponding {@link TranscriptInfoBuilder}
+	 * corresponds to the ucsc kgID. The information is then added to the corresponding {@link TranscriptModelBuilder}
 	 * object.
 	 * <P>
 	 * Note that some of the fields are empty, which can cause a problem for Java's split function, which then conflates

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptModel.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptModel.java
@@ -72,7 +72,7 @@ public final class TranscriptModel implements Serializable, Comparable<Transcrip
 	private static final long serialVersionUID = 3L;
 
 	/**
-	 * Initialize the TranscriptInfo object from the given parameters.
+	 * Initialize the {@link TranscriptModel} object from the given parameters.
 	 */
 	public TranscriptModel(String accession, String geneSymbol, GenomeInterval txRegion, GenomeInterval cdsRegion,
 			ImmutableList<GenomeInterval> exonRegions, String sequence, String geneID, int transcriptSupportLevel) {
@@ -81,7 +81,7 @@ public final class TranscriptModel implements Serializable, Comparable<Transcrip
 	}
 
 	/**
-	 * Initialize the TranscriptInfo object from the given parameters.
+	 * Initialize the {@link TranscriptModel} object from the given parameters.
 	 */
 	public TranscriptModel(String accession, String geneSymbol, GenomeInterval txRegion, GenomeInterval cdsRegion,
 			ImmutableList<GenomeInterval> exonRegions, String sequence, String geneID, int transcriptSupportLevel,

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptModelBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptModelBuilder.java
@@ -16,7 +16,7 @@ import com.google.common.collect.ImmutableSortedSet.Builder;
  * Usage:
  *
  * <pre>
- * {@link TranscriptModelBuilder} builder = new TranscriptInfoBuilder();
+ * {@link TranscriptModelBuilder} builder = new TranscriptModelBuilder();
  * builder.{@link TranscriptModelBuilder#setStrand setStrand}('-');
  * builder.{@link TranscriptModelBuilder#setAccession setAccession}(&quot;&lt;accession&gt;&quot;);
  * // ...
@@ -30,32 +30,32 @@ public class TranscriptModelBuilder {
 	/** The explicit strand of the target transcript. */
 	private Strand strand = Strand.FWD;
 
-	/** {@link TranscriptInfo#accession} of next {@link TranscriptInfo} to build. */
+	/** {@link TranscriptModel#accession} of next {@link TranscriptModel} to build. */
 	private String accession = null;
 
-	/** {@link TranscriptInfo#geneSymbol} of next {@link TranscriptInfo} to build. */
+	/** {@link TranscriptModel#geneSymbol} of next {@link TranscriptModel} to build. */
 	private String geneSymbol = null;
 
-	/** {@link TranscriptInfo#txRegion} of next {@link TranscriptInfo} to build. */
+	/** {@link TranscriptModel#txRegion} of next {@link TranscriptModel} to build. */
 	private GenomeInterval txRegion = null;
 
-	/** {@link TranscriptInfo#cdsRegion} of next {@link TranscriptInfo} to build. */
+	/** {@link TranscriptModel#cdsRegion} of next {@link TranscriptModel} to build. */
 	private GenomeInterval cdsRegion = null;
 
-	/** {@link TranscriptInfo#exonRegions} of next {@link TranscriptInfo} to build. */
+	/** {@link TranscriptModel#exonRegions} of next {@link TranscriptModel} to build. */
 	private ArrayList<GenomeInterval> exonRegions = new ArrayList<GenomeInterval>();
 
-	/** {@link TranscriptInfo#accession} of next {@link TranscriptInfo} to build. */
+	/** {@link TranscriptModel#accession} of next {@link TranscriptModel} to build. */
 	private String sequence = null;
 
-	/** {@link TranscriptInfo#geneID} of next {@link TranscriptInfo} to build. */
+	/** {@link TranscriptModel#geneID} of next {@link TranscriptModel} to build. */
 	private String geneID = null;
 
 	/** Map with alternative gene IDs */
 	private HashMap<String, String> altGeneIDs = new HashMap<String, String>();;
 
 	/**
-	 * {@link TranscriptInfo#transcriptSupportLevel} of next {@link TranscriptInfo} to build.
+	 * {@link TranscriptModel#transcriptSupportLevel} of next {@link TranscriptModel} to build.
 	 *
 	 * @see TranscriptSupportLevels
 	 */
@@ -93,7 +93,7 @@ public class TranscriptModelBuilder {
 			}
 		}
 
-		// Create new TranscriptInfo object.
+		// Create new TranscriptModel object.
 		return new TranscriptModel(accession, geneSymbol, txRegion.withStrand(strand), cdsRegion.withStrand(strand),
 				ImmutableList.copyOf(builder.build()), sequence, geneID, transcriptSupportLevel, altGeneIDs);
 	}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceChangeHelper.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceChangeHelper.java
@@ -10,7 +10,7 @@ import de.charite.compbio.jannovar.Immutable;
 @Immutable
 public final class TranscriptSequenceChangeHelper {
 
-	/** The {@link TranscriptInfo} with the sequence and position infos. */
+	/** The {@link TranscriptModel} with the sequence and position infos. */
 	private final TranscriptModel transcript;
 
 	/**

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceDecorator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceDecorator.java
@@ -13,7 +13,7 @@ import de.charite.compbio.jannovar.impl.util.StringUtil;
 @Immutable
 public final class TranscriptSequenceDecorator {
 
-	/** The wrapped {@link TranscriptInfo}. */
+	/** The wrapped {@link TranscriptModel}. */
 	private final TranscriptModel transcript;
 
 	public TranscriptSequenceDecorator(TranscriptModel transcript) {

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/TranscriptModelBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/TranscriptModelBuilderTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import de.charite.compbio.jannovar.data.ReferenceDictionary;
 
-public class TranscriptInfoBuilderTest {
+public class TranscriptModelBuilderTest {
 
 	/** this test uses this static hg19 reference dictionary */
 	static final ReferenceDictionary refDict = HG19RefDictBuilder.build();

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/TranscriptModelTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/TranscriptModelTest.java
@@ -10,11 +10,11 @@ import de.charite.compbio.jannovar.reference.TranscriptModel;
 import de.charite.compbio.jannovar.reference.TranscriptModelBuilder;
 
 /**
- * Tests for the TranscriptInfo class.
+ * Tests for the {@link TranscriptModel} class.
  *
  * @author <a href="mailto:manuel.holtgrewe@charite.de">Manuel Holtgrewe</a>
  */
-public class TranscriptInfoTest {
+public class TranscriptModelTest {
 
 	/** this test uses this static hg19 reference dictionary */
 	static final ReferenceDictionary refDict = HG19RefDictBuilder.build();


### PR DESCRIPTION
Removes mentions of `TranscriptInfo` in javadocs etc and replaces it with `TranscriptModel`, basically cleaning up some left-overs from https://github.com/charite/jannovar/pull/79. 