### PR TITLE
#350: stop loss annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ manual/_build
 # Java Mission Control flight recorder files
 *.jfr
 .attach_pid*
+.idea

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceDecorator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptSequenceDecorator.java
@@ -84,10 +84,11 @@ public final class TranscriptSequenceDecorator {
 	public String getCodonAt(TranscriptPosition txPos, CDSPosition cdsPos) throws InvalidCodonException {
 		int frameShift = cdsPos.getPos() % 3;
 		int codonStart = txPos.getPos() - frameShift; // codon start in transcript string
-		if (transcript.getSequence().length() <= codonStart + 3)
-			throw new InvalidCodonException("Could not access codon " + codonStart + " - " + (codonStart + 3)
+		int endPos = codonStart + 3;
+		if (transcript.getSequence().length() < endPos)
+			throw new InvalidCodonException("Could not access codon " + codonStart + " - " + endPos
 					+ ", transcript sequence length is " + transcript.getSequence().length());
-		return transcript.getSequence().substring(codonStart, codonStart + 3);
+		return transcript.getSequence().substring(codonStart, endPos);
 	}
 
 	/**

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/TranscriptSequenceDecoratorTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/TranscriptSequenceDecoratorTest.java
@@ -1,0 +1,49 @@
+package de.charite.compbio.jannovar.reference;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for {@link TranscriptSequenceDecorator}.
+ */
+public class TranscriptSequenceDecoratorTest {
+
+	private static final String[] CODONS = { "ATG", "ATC", "AGA", "GCT", "TGA" };
+
+	private static final int START_LAST_CODON = 12;
+
+	private static final TranscriptModel MODEL = getTestTranscriptModel();
+
+	@Test
+	public void testGetCodonAt() throws Exception {
+		TranscriptSequenceDecorator decorator = new TranscriptSequenceDecorator(MODEL);
+		Assert.assertEquals(CODONS[CODONS.length - 1], decorator.getCodonAt(tx(START_LAST_CODON), cds(START_LAST_CODON)));
+		Assert.assertEquals(CODONS[0], decorator.getCodonAt(tx(0), cds(0)));
+	}
+
+	@Test
+	public void testGetCodonsStartingFrom() throws Exception {
+		TranscriptSequenceDecorator decorator = new TranscriptSequenceDecorator(MODEL);
+		Assert.assertEquals(CODONS[0] + CODONS[1], decorator.getCodonsStartingFrom(tx(0), cds(0), 2));
+		Assert.assertEquals(CODONS[CODONS.length - 2] + CODONS[CODONS.length - 1],
+				decorator.getCodonsStartingFrom(tx(9), cds(9), 2));
+	}
+
+	private static TranscriptModel getTestTranscriptModel() {
+		String sequence = Joiner.on("").join(CODONS);
+		return new TranscriptModel("TEST", "TEST", new GenomeInterval(null, Strand.FWD, 1, 0, sequence.length()),
+				new GenomeInterval(null, Strand.FWD, 1, 0, sequence.length()), ImmutableList.<GenomeInterval>builder().build(),
+				sequence, "TEST", 1);
+	}
+
+	private static TranscriptPosition tx(int pos) {
+		return new TranscriptPosition(MODEL, pos);
+	}
+
+	private static CDSPosition cds(int pos) {
+		return new CDSPosition(MODEL, pos);
+	}
+
+}


### PR DESCRIPTION
This fixes #350 and produces the following output for `NM_001128223.1`, when running `java -jar jannovar-cli-0.23-SNAPSHOT.jar annotate-vcf --show-all -d data/hg19_refseq.ser -i stop_loss.vcf -o stop_loss_out_fixed.vcf`:

````
C|stop_lost|HIGH|ZNF717|100131827|transcript|NM_001128223.1|Coding|5/5|c.2743T>G|p.(*915Glyext*-915)|3066/48227|2743/2745|915/915||
````

It adds some tests for `TranscriptSequenceDecorator` (`TranscriptSequenceDecoratorTest`) and corrects the overly strict check in `TranscriptSequenceDecorator#getCodonAt(...)`.