### PR TITLE
Update HTSJDK because there is a bug in generating index files with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## develop (unreleased)
 
+### overall
+
+* Changing HTSJDK version to 2.11.0
+
+
+
 ## v0.23
 
 ### overall

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>Jannovar</name>
 
     <properties>
-        <htsjdk.version>2.8.1</htsjdk.version>
+        <htsjdk.version>2.11.0</htsjdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <log4j.version>2.8.2</log4j.version>
 


### PR DESCRIPTION
Update HTSJDK to 2.11.0 because there is a bug in generating index files with large VCF headers (which might affect jannovar, when multiple sources are annotated).