### PR TITLE
Hotfix/deletion over the stop codon

### DIFF
--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
@@ -243,13 +243,15 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 
 			// Handle the case of deleting a stop codon at the very last entry of the translated amino acid string and
 			// short-circuit.
+			// == is correct even if getPos() is zero based 
+			// because getPos points to the stop position which is one base after the AA sequence
 			if (varTypes.contains(VariantEffect.STOP_LOST) && aaChange.getPos() == varAASeq.length()) {
 				// Note: used to be "p.*${pos}del?"
 				proteinChange = ProteinMiscChange.build(true, ProteinMiscChangeType.DIFFICULT_TO_PREDICT);
 				return;
 			}
 			// Handle the case of deleting up to the end of the sequence.
-			if (aaChange.getPos() >= varAASeq.length()) {
+			if (aaChange.getLastPos() >= varAASeq.length()) {
 				final String wtAAFirst = Character.toString(wtAASeq.charAt(aaChange.getPos()));
 				final String wtAALast = Character.toString(wtAASeq.charAt(aaChange.getLastPos()));
 				if (aaChange.getRef().length() == 1)

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -1264,7 +1264,7 @@ public class DeletionAnnotationBuilderTest {
 
 	@Test
 	public void testRealWorldCase_uc001sbo_3() throws InvalidGenomeVariant {
-		// TODO This test is not so well defined because the transcript has no real stop codon (AGG follows a Serin...)
+		// TODO This test is not so well defined because the transcript has no real stop codog (AGG follows a Serin...)
 		this.builderForward = TranscriptModelFactory
 				.parseKnownGenesLine(
 						refDict,

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -1264,6 +1264,7 @@ public class DeletionAnnotationBuilderTest {
 
 	@Test
 	public void testRealWorldCase_uc001sbo_3() throws InvalidGenomeVariant {
+		// TODO This test is not so well defined because the transcript has no real stop codon (AGG follows a Serin...)
 		this.builderForward = TranscriptModelFactory
 				.parseKnownGenesLine(
 						refDict,


### PR DESCRIPTION
closes #361


https://github.com/charite/jannovar/blob/44333688c7c319623761478cd5d7d210fbc4d8dc/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java#L246

The line is correct. Here the stop-codon is shown and this is one base AFTER the sequence. So because getPos is zero-based it is fine!

I think getPos  must be chnanged to getLastPos here:

https://github.com/charite/jannovar/blob/44333688c7c319623761478cd5d7d210fbc4d8dc/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java#L252
