### PR TITLE
Bugfix in GenomeRegionSequenceExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Changing HTSJDK version to 2.14.0
 * Codestyle approvements
 
+### jannovar-htsjdk
+
+* Fixing bug in GenomeRegionSequenceExtraction. Error reports always sequences from the first contig in the referebnce file and not the requested contig. Affects only the cli command hgvs-to-vcf.
+
 ### jannovar-core
 
 * Fixing mendelian "bug" #393 (has no affect because check was not necessary)

--- a/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/GenomeRegionSequenceExtractor.java
+++ b/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/GenomeRegionSequenceExtractor.java
@@ -56,8 +56,12 @@ public class GenomeRegionSequenceExtractor {
 		String nameInFasta = null;
 		for (SAMSequenceRecord record : indexedFile.getSequenceDictionary().getSequences()) {
 			if (jannovarData.getRefDict().getContigNameToID().containsKey(record.getSequenceName())) {
-				nameInFasta = record.getSequenceName();
-				break;
+				String contigInFasta = record.getSequenceName();
+				if (jannovarData.getRefDict().getContigNameToID().get(contigInFasta) == contigID) {
+					nameInFasta = contigInFasta;
+					break;
+				}
+				
 			}
 		}
 		if (nameInFasta == null)


### PR DESCRIPTION
ixing bug in GenomeRegionSequenceExtraction. Error reports always sequences from the first contig in the referebnce file and not the requested contig. Affects only the cli command hgvs-to-vcf. (LUCK!)