### PR TITLE
Hotfix/one letter amino acid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### overall
 
 * Changing HTSJDK version to 2.14.3
+* Using the one letter amino acid code in HGVS representation as default (changes in core, hgvs, htsjdk and cli). Now the cli option `--3-letter-amino-acids` works as expected.
 
 ### jannovar-htsjdk
 

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotateVCFCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/annotate_vcf/AnnotateVCFCommand.java
@@ -14,6 +14,7 @@ import de.charite.compbio.jannovar.filter.facade.GenotypeThresholdFilterAnnotato
 import de.charite.compbio.jannovar.filter.facade.ThresholdFilterHeaderExtender;
 import de.charite.compbio.jannovar.filter.facade.ThresholdFilterOptions;
 import de.charite.compbio.jannovar.filter.impl.var.VariantThresholdFilterAnnotator;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.htsjdk.VariantContextAnnotator;
 import de.charite.compbio.jannovar.htsjdk.VariantContextWriterConstructionHelper;
 import de.charite.compbio.jannovar.htsjdk.VariantEffectHeaderExtender;
@@ -230,7 +231,8 @@ public class AnnotateVCFCommand extends JannovarAnnotationCommand {
 			extender.addHeaders(vcfHeader);
 			VariantContextAnnotator variantEffectAnnotator =
 					new VariantContextAnnotator(refDict, chromosomeMap,
-							new VariantContextAnnotator.Options(!options.isShowAll(),
+							new VariantContextAnnotator.Options(!options.isShowAll(), 
+									(options.isUseThreeLetterAminoAcidCode() ? AminoAcidCode.THREE_LETTER : AminoAcidCode.ONE_LETTER),
 									options.isEscapeAnnField(), options.isNt3PrimeShifting(),
 									options.isOffTargetFilterEnabled(),
 									options.isOffTargetFilterUtrIsOffTarget(),

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/statistics/GatherStatisticsCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/statistics/GatherStatisticsCommand.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 import de.charite.compbio.jannovar.JannovarException;
 import de.charite.compbio.jannovar.cmd.CommandLineParsingException;
 import de.charite.compbio.jannovar.cmd.JannovarAnnotationCommand;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.htsjdk.InvalidCoordinatesException;
 import de.charite.compbio.jannovar.htsjdk.VariantContextAnnotator;
 import de.charite.compbio.jannovar.stats.facade.StatisticsCollector;
@@ -45,7 +46,7 @@ public class GatherStatisticsCommand extends JannovarAnnotationCommand {
 		final boolean isUtrOffTarget = false;
 		final boolean isIntronicSpliceOffTarget = false;
 		VariantContextAnnotator annotator = new VariantContextAnnotator(refDict, chromosomeMap,
-				new VariantContextAnnotator.Options(false, false, false, false, isUtrOffTarget,
+				new VariantContextAnnotator.Options(false, AminoAcidCode.ONE_LETTER, false, false, false, isUtrOffTarget,
 						isIntronicSpliceOffTarget));
 
 		Map<String, Integer> errorMsgs = new TreeMap<>();

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/Annotation.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/Annotation.java
@@ -213,7 +213,7 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 
 	/**
 	 * @param code
-	 *            the protein change code to use.
+	 *            Three ore one letter amino acid code
 	 * @return protein change String, including the "p." prefix or the empty string if there is no annotation.
 	 */
 	public String getProteinChangeStr(AminoAcidCode code) {
@@ -260,11 +260,13 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 	 * 
 	 * @param alt
 	 *            alt allele
+	 * @param code
+	 *            Three or one letter amino acid code
 	 * @param escape
 	 *            whether or not to escape the invalid VCF characters, e.g. <code>'='</code>.
 	 * @return VCF annotation string
 	 */
-	public String toVCFAnnoString(String alt, boolean escape) {
+	public String toVCFAnnoString(String alt, boolean escape, AminoAcidCode code) {
 		VCFAnnotationData data = new VCFAnnotationData();
 		data.effects = effects;
 		data.impact = getPutativeImpact();
@@ -275,20 +277,23 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 		data.proteinChange = proteinChange;
 		data.messages = messages;
 		if (escape)
-			return data.toString(alt);
+			return data.toString(alt, code);
 		else
-			return data.toUnescapedString(alt);
+			return data.toUnescapedString(alt, code);
 	}
 
 	/**
-	 * Forward to {@link #toVCFAnnoString(String, boolean) toVCFAnnoString(alt, true)}.
+	 * Forward to {@link #toVCFAnnoString(String, boolean, AminoAcidCode)
+	 * toVCFAnnoString(alt, true, code)}.
 	 * 
 	 * @param alt
 	 *            alternateve allele
+	 * @param code
+	 *            Three ore one letter amino acid code
 	 * @return vcf annotation string
 	 */
-	public String toVCFAnnoString(String alt) {
-		return toVCFAnnoString(alt, true);
+	public String toVCFAnnoString(String alt, AminoAcidCode code) {
+		return toVCFAnnoString(alt, true, code);
 	}
 
 	/**
@@ -310,7 +315,7 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 	 * string, e.g., <code>"KIAA1751:uc001aim.1:exon18:c.T2287C:p.X763Q"</code>.
 	 * 
 	 * @param code
-	 *            the amino acid code
+	 *            Three ore one letter amino acid code
 	 *
 	 * @return full annotation string or <code>null</code> if {@link #transcript} is <code>null</code>
 	 */

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VCFAnnotationData.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VCFAnnotationData.java
@@ -6,6 +6,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSortedSet;
 
 import de.charite.compbio.jannovar.annotation.AnnotationLocation.RankType;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.hgvs.nts.change.NucleotideChange;
 import de.charite.compbio.jannovar.hgvs.protein.change.ProteinChange;
 import de.charite.compbio.jannovar.reference.GenomeVariant;
@@ -108,20 +109,22 @@ class VCFAnnotationData {
 	/**
 	 * @param allele
 	 *            String with the allele value to prepend to the returned array
+	 * @param code
+	 *            Three ore one letter amino acid code
 	 * @return array of objects to be converted to string and joined, the alternative allele is given by
 	 */
-	public Object[] toArray(String allele) {
+	public Object[] toArray(String allele, AminoAcidCode code) {
 		final Joiner joiner = Joiner.on('&').useForNull("");
 		final String effectsString = joiner.join(FluentIterable.from(effects).transform(VariantEffect.TO_SO_TERM));
 		return new Object[] { allele, effectsString, impact, geneSymbol, geneID, featureType, featureID,
 				featureBioType, getRankString(),
 				(cdsNTChange == null) ? cdsNTChange : ((isCoding ? "c." : "n.") + cdsNTChange.toHGVSString()),
-				(proteinChange == null) ? proteinChange : ("p." + proteinChange.toHGVSString()), getTXPosString(),
+				(proteinChange == null) ? proteinChange : ("p." + proteinChange.toHGVSString(code)), getTXPosString(),
 				getCDSPosString(), getAminoAcidPosString(), getDistanceString(), joiner.join(messages) };
 	}
 
-	public String toUnescapedString(String allele) {
-		return Joiner.on('|').useForNull("").join(toArray(allele));
+	public String toUnescapedString(String allele, AminoAcidCode code) {
+		return Joiner.on('|').useForNull("").join(toArray(allele, code));
 	}
 
 	private String escape(String str) {
@@ -140,10 +143,12 @@ class VCFAnnotationData {
 	/**
 	 * @param allele
 	 *            alternative allele value to prepend
+ 	 * @param code
+	 *            Three ore one letter amino acid code
 	 * @return String for putting into the "ANN" field of the VCF file
 	 */
-	public String toString(String allele) {
-		return escape(toUnescapedString(allele));
+	public String toString(String allele, AminoAcidCode code) {
+		return escape(toUnescapedString(allele, code));
 	}
 
 	private String getRankString() {

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilderTest.java
@@ -11,6 +11,7 @@ import de.charite.compbio.jannovar.annotation.AnnotationLocation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeVariant;
 import de.charite.compbio.jannovar.annotation.VariantEffect;
 import de.charite.compbio.jannovar.data.ReferenceDictionary;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.reference.GenomePosition;
 import de.charite.compbio.jannovar.reference.GenomeVariant;
 import de.charite.compbio.jannovar.reference.HG19RefDictBuilder;
@@ -173,7 +174,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1_3delACGinsCGTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1.getEffects());
 
 		// Delete chunk out of first exon, spanning start codon from the left.
@@ -184,7 +185,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("-9_2delCCCTCCAGACCinsGTTG", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation2.getEffects());
 
 		// Delete chunk out of first exon, spanning start codon from the right.
@@ -195,7 +196,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3.getAnnoLoc().getRank());
 		Assert.assertEquals("3_13delGGACGGCTCCTinsCTTG", annotation3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation3.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation3.getEffects());
 
 		// Deletion from before transcript, reaching into the start codon.
@@ -210,7 +211,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(
 				"-69-201_1delTCTCACCAGGCCCTTCTTCACGACCCTGGCCCCCCATCCAGCATCCCCCCTGGCCAATCCAATATGGCCCCCGGCCCCCGGGAGGCTGTCAGTGTGTTCCAGCCCTCCGCGTGCACCCCTCACCCTGACCCAAGCCCTCGTGCTGATAAATATGATTATTTGAGTAGAGGCCAACTTCCCGTTTCTCTCTCTTGACTCCAGGAGCTTTCTCTTGCATACCCTCGCTTAGGCTGGCCGGGGTGTCACTTCTGCCTCCCTGCCCTCCAGACCAinsACCT",
 				annotation4.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation4.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation4.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation4.getEffects());
 	}
 
@@ -225,7 +226,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2067_*2delACGinsCGTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Tyrext*25)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Tyrext*25)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.COMPLEX_SUBSTITUTION, VariantEffect.STOP_LOST),
 				annotation1.getEffects());
 
@@ -237,7 +238,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("2066_*1delACTinsCGGTCG", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Serext*17)", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Serext*17)", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION,
 				VariantEffect.COMPLEX_SUBSTITUTION, VariantEffect.STOP_LOST), annotation2.getEffects());
@@ -250,7 +251,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation3.getAnnoLoc().getRank());
 		Assert.assertEquals("2065_2067delACGinsCGGT", annotation3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Argext*16)", annotation3.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Argext*16)", annotation3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		// Note that the transcript here differs to the one Mutalyzer uses after the CDS.
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.COMPLEX_SUBSTITUTION,
 				VariantEffect.STOP_LOST), annotation3.getEffects());
@@ -266,7 +267,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("691-1delGinsTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT), annotation1.getEffects());
 
@@ -278,7 +279,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("691_693delTGGinsAA", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Trp231Lysfs*23)", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Trp231Lysfs*23)", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.COMPLEX_SUBSTITUTION,
 				VariantEffect.SPLICE_REGION_VARIANT), annotation2.getEffects());
 	}
@@ -293,7 +294,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1225_1234delTGCCCCACCTinsCCC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Cys409Profs*127)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Cys409Profs*127)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION,
 				VariantEffect.COMPLEX_SUBSTITUTION, VariantEffect.SPLICE_REGION_VARIANT), annotation1.getEffects());
 	}
@@ -308,7 +309,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(AnnotationLocation.INVALID_RANK, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("691-3_693delTAAACAinsGTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Trp231Val)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Trp231Val)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.COMPLEX_SUBSTITUTION,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT, VariantEffect.FEATURE_TRUNCATION), annotation1.getEffects());
 
@@ -320,7 +321,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("700_708delGTGGTTCAAinsACC", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val234_Gln236delinsThr)", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val234_Gln236delinsThr)", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FEATURE_TRUNCATION, VariantEffect.COMPLEX_SUBSTITUTION),
 				annotation2.getEffects());
@@ -333,7 +334,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation3.getAnnoLoc().getRank());
 		Assert.assertEquals("708_716delAGTGGAGGAinsCT", annotation3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln236Hisfs*16)", annotation3.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln236Hisfs*16)", annotation3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION, VariantEffect.COMPLEX_SUBSTITUTION),
 				annotation3.getEffects());
@@ -359,7 +360,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("96_112delTAAGAAGGAGACCATCAinsACTACCAGAGGAAT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Lys33_Met38delinsLeuProGluGluLeu)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Lys33_Met38delinsLeuProGluGluLeu)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.COMPLEX_SUBSTITUTION, VariantEffect.FEATURE_TRUNCATION),
 				annotation1.getEffects());
@@ -383,7 +384,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("713_718delTCAACAinsACAACACT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu238Hisfs*19)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu238Hisfs*19)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION, VariantEffect.COMPLEX_SUBSTITUTION),
 				annotation1.getEffects());
@@ -409,7 +410,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("475_477delACGinsCTC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr159Leu)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr159Leu)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MNV), annotation1.getEffects());
 	}
 
@@ -433,7 +434,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("96_112delTAAGAAGGAGACCATCAinsACTACCAGAGGAAT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Lys33_Met38delinsLeuProGluGluLeu)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Lys33_Met38delinsLeuProGluGluLeu)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FEATURE_TRUNCATION, VariantEffect.COMPLEX_SUBSTITUTION),
 				annotation1.getEffects());
@@ -459,7 +460,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("475_480delACGACTinsTAGCTC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr159*)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr159*)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MNV, VariantEffect.STOP_GAINED),
 				annotation1.getEffects());
 	}
@@ -484,7 +485,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("830_831delCAinsTG", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala277Val)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala277Val)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MNV), annotation1.getEffects());
 	}
 
@@ -509,7 +510,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(AnnotationLocation.INVALID_RANK, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1263_1266+1delTGAGGinsC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu422del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu422del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.COMPLEX_SUBSTITUTION,
 				VariantEffect.SPLICE_DONOR_VARIANT, VariantEffect.FEATURE_TRUNCATION), annotation1.getEffects());
 	}
@@ -535,7 +536,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(AnnotationLocation.INVALID_RANK, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("453_453+6delGGTGATCinsA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.COMPLEX_SUBSTITUTION,
 				VariantEffect.SPLICE_DONOR_VARIANT, VariantEffect.FEATURE_TRUNCATION), annotation1.getEffects());
 	}
@@ -560,7 +561,7 @@ public class BlockSubstitutionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6332+2_6332+4delTACinsCCT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -12,6 +12,7 @@ import de.charite.compbio.jannovar.annotation.AnnotationLocation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeVariant;
 import de.charite.compbio.jannovar.annotation.VariantEffect;
 import de.charite.compbio.jannovar.data.ReferenceDictionary;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.reference.GenomePosition;
 import de.charite.compbio.jannovar.reference.GenomeVariant;
 import de.charite.compbio.jannovar.reference.HG19RefDictBuilder;
@@ -122,7 +123,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(AnnotationLocation.INVALID_RANK, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-204_-70+65del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.TRANSCRIPT_ABLATION), annotation1.getEffects());
 	}
 
@@ -135,7 +136,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("691-11del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
 				annotation1.getEffects());
 	}
@@ -149,7 +150,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-192del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -162,7 +163,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*59del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -178,7 +179,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1.getEffects());
 
 		// Delete chunk out of first exon, spanning start codon from the left.
@@ -189,7 +190,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("-9_2del", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation2.getEffects());
 
 		// Delete chunk out of first exon, spanning start codon from the right.
@@ -200,7 +201,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3.getAnnoLoc().getRank());
 		Assert.assertEquals("3_13del", annotation3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation3.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation3.getEffects());
 
 		// Deletion from before transcript, reaching into the start codon.
@@ -213,7 +214,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4.getTranscript().getAccession());
 		Assert.assertEquals(AnnotationLocation.INVALID_RANK, annotation4.getAnnoLoc().getRank());
 		Assert.assertEquals("-69-201_1del", annotation4.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation4.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation4.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation4.getEffects());
 	}
 
@@ -230,7 +231,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2067del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Tyrext*?)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Tyrext*?)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.STOP_LOST),
 				annotation1.getEffects());
 
@@ -242,7 +243,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("2066del", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Cysext*?)", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Cysext*?)", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.STOP_LOST),
 				annotation2.getEffects());
 
@@ -254,7 +255,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation3.getAnnoLoc().getRank());
 		Assert.assertEquals("2065del", annotation3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Serext*?)", annotation3.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Serext*?)", annotation3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.STOP_LOST),
 				annotation3.getEffects());
 
@@ -266,7 +267,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation4.getAnnoLoc().getRank());
 		Assert.assertEquals("2065_2066del", annotation4.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Alaext*15)", annotation4.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Alaext*15)", annotation4.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION, VariantEffect.STOP_LOST),
 				annotation4.getEffects());
 
@@ -278,7 +279,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation5.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation5.getAnnoLoc().getRank());
 		Assert.assertEquals("2063_*3del", annotation5.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Hisext*14)", annotation5.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Hisext*14)", annotation5.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION, VariantEffect.STOP_LOST),
 				annotation5.getEffects());
 	}
@@ -293,7 +294,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("691-1del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT), annotation1.getEffects());
 
@@ -305,7 +306,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("691_693del", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Trp231del)", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Trp231del)", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_DELETION, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation2.getEffects());
 	}
@@ -320,7 +321,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("943_952del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly315Profs*26)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly315Profs*26)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -335,7 +336,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(AnnotationLocation.INVALID_RANK, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("691-3_693del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Trp231del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Trp231del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_DELETION, VariantEffect.SPLICE_ACCEPTOR_VARIANT),
 				annotation1.getEffects());
@@ -348,7 +349,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("704_712del", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val235_Val237del)", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val235_Val237del)", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation2.getEffects());
 
 		// deletion of three codons, resulting in delins case
@@ -359,7 +360,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation3.getAnnoLoc().getRank());
 		Assert.assertEquals("708_716del", annotation3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln236_Asp239delinsHis)", annotation3.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln236_Asp239delinsHis)", annotation3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation3.getEffects());
 	}
 
@@ -383,7 +384,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("119_123del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln40Profs*18)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln40Profs*18)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -405,7 +406,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("488_490del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser163del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser163del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -429,7 +430,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1476_1477del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asn494Profs*38)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asn494Profs*38)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -451,7 +452,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("369_377del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val124_Thr126del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val124_Thr126del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -473,7 +474,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("275_285del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ile92Argfs*26)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ile92Argfs*26)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -497,7 +498,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1503_1507del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu501Aspfs*96)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu501Aspfs*96)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -519,7 +520,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1219_1221del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val407del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val407del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -541,7 +542,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("985del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr329Leufs*17)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr329Leufs*17)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -572,7 +573,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("324_326del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Phe109del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Phe109del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -596,7 +597,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("324_326del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Phe109del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Phe109del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -620,7 +621,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1542_1544del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr517del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr517del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -644,7 +645,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("791_792del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Lys264Argfs*10)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Lys264Argfs*10)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -668,7 +669,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("890_892del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu297_Lys298delinsGln)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu297_Lys298delinsGln)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -690,7 +691,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("422_425del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Cys141Serfs*21)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Cys141Serfs*21)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -714,7 +715,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("377del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Pro126Glnfs*18)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Pro126Glnfs*18)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -738,7 +739,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("542_543del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu181Hisfs*20)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu181Hisfs*20)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -762,7 +763,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("404_421del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu135_Leu140del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu135_Leu140del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -786,7 +787,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("100_102del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Lys34del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Lys34del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -810,7 +811,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(13, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("842_844del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu281del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu281del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -835,7 +836,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1310del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly437Valfs*5)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly437Valfs*5)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
@@ -861,7 +862,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("243_248del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu82_Gln83del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu82_Gln83del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -885,7 +886,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("552_557del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser185_Leu186del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser185_Leu186del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -913,7 +914,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("560del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly187Valfs*23)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly187Valfs*23)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
@@ -939,7 +940,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("317_318del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Pro106Argfs*?)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Pro106Argfs*?)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -961,7 +962,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("72_90del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser25Hisfs*78)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser25Hisfs*78)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -985,7 +986,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1152_1157del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(His384_Arg386delinsGln)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(His384_Arg386delinsGln)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_DELETION), annotation1.getEffects());
 	}
 
@@ -1009,7 +1010,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-25del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1033,7 +1034,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-7_-6del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1057,7 +1058,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-11_-5del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1081,7 +1082,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("315-2del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT), annotation1.getEffects());
 	}
@@ -1106,7 +1107,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1027del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val343Trpfs*33)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val343Trpfs*33)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION, VariantEffect.SPLICE_DONOR_VARIANT),
 				annotation1.getEffects());
@@ -1205,7 +1206,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(12, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1068_1071del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu358del)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu358del)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
 	}
 
@@ -1229,7 +1230,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2461del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION, VariantEffect.STOP_LOST),
 				annotation1.getEffects());
 	}
@@ -1256,7 +1257,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(14, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2296del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Arg766Glyfs*77)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Arg766Glyfs*77)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION, VariantEffect.SPLICE_DONOR_VARIANT),
 				annotation1.getEffects());
@@ -1284,7 +1285,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(-1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1260_*10del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*420Serext*?)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*420Serext*?)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.STOP_LOST),
 				annotation1.getEffects());
 	}
@@ -1311,7 +1312,7 @@ public class DeletionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("138+1del", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -11,6 +11,7 @@ import de.charite.compbio.jannovar.annotation.AnnotationLocation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeVariant;
 import de.charite.compbio.jannovar.annotation.VariantEffect;
 import de.charite.compbio.jannovar.data.ReferenceDictionary;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.reference.GenomePosition;
 import de.charite.compbio.jannovar.reference.GenomeVariant;
 import de.charite.compbio.jannovar.reference.HG19RefDictBuilder;
@@ -117,7 +118,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(3, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("1044+8_1044+9insA", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), anno.getEffects());
 	}
 
@@ -129,7 +130,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(1, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("-1dup", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
@@ -141,7 +142,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(10, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("2067_*1insA", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
@@ -154,7 +155,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(2, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("691-1_691insACT", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), anno.getEffects());
 	}
@@ -174,7 +175,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1agc.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1agc.getAnnoLoc().getRank());
 		Assert.assertEquals("2066_2067insAGC", annotation1agc.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1agc.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1agc.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1agc.getEffects());
 
 		// The WT stop codon is destroyed but there is a new one downstream
@@ -185,7 +186,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1tgc.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1tgc.getAnnoLoc().getRank());
 		Assert.assertEquals("2066_2067insTGC", annotation1tgc.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Tyrext*24)", annotation1tgc.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Tyrext*24)", annotation1tgc.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), annotation1tgc.getEffects());
 
 		// Test case where the start codon is destroyed.
@@ -196,7 +197,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2agc.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation2agc.getAnnoLoc().getRank());
 		Assert.assertEquals("1_2insAGC", annotation2agc.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation2agc.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation2agc.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.START_LOST),
 				annotation2agc.getEffects());
 
@@ -210,7 +211,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3taa.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3taa.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insTAA", annotation3taa.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2*)", annotation3taa.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2*)", annotation3taa.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.STOP_GAINED),
 				annotation3taa.getEffects());
 
@@ -222,7 +223,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3tcctaa.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3tcctaa.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insTCCTAA", annotation3tcctaa.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2_Gly3delinsSer)", annotation3tcctaa.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2_Gly3delinsSer)", annotation3tcctaa.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.STOP_GAINED),
 				annotation3tcctaa.getEffects());
 
@@ -234,7 +235,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4tcctcctcc.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4tcctcctcc.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insTCCTCCTCC", annotation4tcctcctcc.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Met1_Asp2insSerSerSer)", annotation4tcctcctcc.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Met1_Asp2insSerSerSer)", annotation4tcctcctcc.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION), annotation4tcctcctcc.getEffects());
 
 		// Insertion without a new stop codon that is a duplication.
@@ -245,7 +246,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation5gatggc.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation5gatggc.getAnnoLoc().getRank());
 		Assert.assertEquals("5_6insTGGCGA", annotation5gatggc.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2_Gly3dup)", annotation5gatggc.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2_Gly3dup)", annotation5gatggc.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_INSERTION,
 				VariantEffect.DIRECT_TANDEM_DUPLICATION), annotation5gatggc.getEffects());
 	}
@@ -262,7 +263,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1_2insG", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1.getEffects());
 
 		GenomeVariant change2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640671,
@@ -272,7 +273,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("2_3insA", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation2.getEffects());
 
 		// Try to insert all non-duplicate NTs between 3 and 4.
@@ -284,7 +285,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3a.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3a.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insA", annotation3a.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Argfs*37)", annotation3a.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Argfs*37)", annotation3a.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation3a.getEffects());
 
 		GenomeVariant change3c = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640672,
@@ -294,7 +295,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3c.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3c.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insC", annotation3c.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Argfs*37)", annotation3c.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Argfs*37)", annotation3c.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation3c.getEffects());
 
 		GenomeVariant change3t = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640672,
@@ -304,7 +305,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3t.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3t.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insT", annotation3t.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2*)", annotation3t.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2*)", annotation3t.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation3t.getEffects());
 
 		// Try to insert all non-duplicate NTs between 4 and 5.
@@ -316,7 +317,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4c.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4c.getAnnoLoc().getRank());
 		Assert.assertEquals("4_5insC", annotation4c.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Alafs*37)", annotation4c.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Alafs*37)", annotation4c.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation4c.getEffects());
 
 		GenomeVariant change4t = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640673,
@@ -326,7 +327,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4t.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4t.getAnnoLoc().getRank());
 		Assert.assertEquals("4_5insT", annotation4t.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Valfs*37)", annotation4t.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Valfs*37)", annotation4t.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation4t.getEffects());
 
 		// Try to insert all non-duplicate NTs between 5 and 6.
@@ -338,7 +339,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation5g.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation5g.getAnnoLoc().getRank());
 		Assert.assertEquals("5_6insG", annotation5g.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Glufs*37)", annotation5g.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Glufs*37)", annotation5g.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation5g.getEffects());
 
 		GenomeVariant change5t = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640674,
@@ -348,7 +349,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation5t.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation5t.getAnnoLoc().getRank());
 		Assert.assertEquals("5_6insT", annotation5t.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly3Argfs*36)", annotation5t.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly3Argfs*36)", annotation5t.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation5t.getEffects());
 
 		// It appears to be impossible to force a stop loss for this transcript.
@@ -361,7 +362,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation6t.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation6t.getAnnoLoc().getRank());
 		Assert.assertEquals("2066_2067insT", annotation6t.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Tyrext*15)", annotation6t.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Tyrext*15)", annotation6t.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation6t.getEffects());
 
 		GenomeVariant change6c = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649270,
@@ -371,7 +372,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation6c.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation6c.getAnnoLoc().getRank());
 		Assert.assertEquals("2065_2066insC", annotation6c.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Serext*15)", annotation6c.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Serext*15)", annotation6c.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation6c.getEffects());
 
 		// Test for no change when inserting into stop codon.
@@ -382,7 +383,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation7g.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation7g.getAnnoLoc().getRank());
 		Assert.assertEquals("2065_2066insG", annotation7g.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation7g.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation7g.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation7g.getEffects());
 	}
 
@@ -398,7 +399,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1_2insGA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1.getEffects());
 
 		GenomeVariant change2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640671,
@@ -408,7 +409,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("2_3insAG", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation2.getEffects());
 
 		// Try to insert some non-duplicate NT pairs between 3 and 4.
@@ -420,7 +421,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3ac.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3ac.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insAC", annotation3ac.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Thrfs*10)", annotation3ac.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Thrfs*10)", annotation3ac.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation3ac.getEffects());
 
 		GenomeVariant change3cg = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640672,
@@ -430,7 +431,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3cg.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3cg.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insCG", annotation3cg.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Argfs*10)", annotation3cg.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Argfs*10)", annotation3cg.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation3cg.getEffects());
 
 		GenomeVariant change3ta = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640672,
@@ -440,7 +441,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation3ta.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3ta.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insTA", annotation3ta.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2*)", annotation3ta.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2*)", annotation3ta.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation3ta.getEffects());
 
 		// Try to insert some non-duplicate NT pairs between 4 and 5.
@@ -452,7 +453,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4ct.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4ct.getAnnoLoc().getRank());
 		Assert.assertEquals("4_5insCT", annotation4ct.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Alafs*10)", annotation4ct.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Alafs*10)", annotation4ct.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation3cg.getEffects());
 
 		GenomeVariant change4tg = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640673,
@@ -462,7 +463,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4tg.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4tg.getAnnoLoc().getRank());
 		Assert.assertEquals("4_5insTG", annotation4tg.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Valfs*10)", annotation4tg.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Valfs*10)", annotation4tg.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation3ta.getEffects());
 
 		// Try to insert some non-duplicate NT pairs between 5 and 6.
@@ -474,7 +475,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation5gc.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation5gc.getAnnoLoc().getRank());
 		Assert.assertEquals("5_6insGC", annotation5gc.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Glufs*10)", annotation5gc.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Glufs*10)", annotation5gc.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation3ta.getEffects());
 
 		GenomeVariant change5ta = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640674,
@@ -484,7 +485,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation5ta.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation5ta.getAnnoLoc().getRank());
 		Assert.assertEquals("5_6insTA", annotation5ta.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly3Thrfs*9)", annotation5ta.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly3Thrfs*9)", annotation5ta.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation3cg.getEffects());
 	}
 
@@ -502,7 +503,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4actagact.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4actagact.getAnnoLoc().getRank());
 		Assert.assertEquals("6_7insTAGACTAC", annotation4actagact.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly3*)", annotation4actagact.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly3*)", annotation4actagact.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation4actagact.getEffects());
 
 		GenomeVariant change4cgtg = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640673,
@@ -512,7 +513,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation4cgtg.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4cgtg.getAnnoLoc().getRank());
 		Assert.assertEquals("4_5insCGTG", annotation4cgtg.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Alafs*2)", annotation4cgtg.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Alafs*2)", annotation4cgtg.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation4cgtg.getEffects());
 	}
 
@@ -531,7 +532,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation1c.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1c.getAnnoLoc().getRank());
 		Assert.assertEquals("1_2insG", annotation1c.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1c.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1c.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1c.getEffects());
 
 		GenomeVariant change1g = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694497,
@@ -541,7 +542,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation1g.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1g.getAnnoLoc().getRank());
 		Assert.assertEquals("1_2insC", annotation1g.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1g.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1g.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1g.getEffects());
 
 		// Insert A and C between nucleotides 2 and 3.
@@ -553,7 +554,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation2a.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation2a.getAnnoLoc().getRank());
 		Assert.assertEquals("2_3insA", annotation2a.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation2a.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation2a.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation2a.getEffects());
 
 		GenomeVariant change2c = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694496,
@@ -563,7 +564,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation2c.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation2c.getAnnoLoc().getRank());
 		Assert.assertEquals("2_3insC", annotation2c.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation2c.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation2c.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation2c.getEffects());
 
 		// Insertions between nucleotides 3 and 4.
@@ -575,7 +576,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation3a.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3a.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insA", annotation3a.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala2Serfs*16)", annotation3a.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala2Serfs*16)", annotation3a.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation3a.getEffects());
 
 		GenomeVariant change3c = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694495,
@@ -585,7 +586,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation3c.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation3c.getAnnoLoc().getRank());
 		Assert.assertEquals("3_4insC", annotation3c.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala2Argfs*16)", annotation3c.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala2Argfs*16)", annotation3c.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation3c.getEffects());
 
 		// Some insertions into stop codon
@@ -597,7 +598,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation4g.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation4g.getAnnoLoc().getRank());
 		Assert.assertEquals("1411_1412insC", annotation4g.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*471Serext*7)", annotation4g.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*471Serext*7)", annotation4g.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation4g.getEffects());
 
 		GenomeVariant change4c = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688463,
@@ -607,7 +608,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation4c.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation4c.getAnnoLoc().getRank());
 		Assert.assertEquals("1411_1412insG", annotation4c.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation4c.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation4c.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation4c.getEffects());
 	}
 
@@ -625,7 +626,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation4actagact.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4actagact.getAnnoLoc().getRank());
 		Assert.assertEquals("4_5insAGTCTAGT", annotation4actagact.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala2Glufs*16)", annotation4actagact.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala2Glufs*16)", annotation4actagact.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION),
 				annotation4actagact.getEffects());
 
@@ -637,7 +638,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation4cgtg.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation4cgtg.getAnnoLoc().getRank());
 		Assert.assertEquals("6_7insCGCA", annotation4cgtg.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala3Argfs*16)", annotation4cgtg.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala3Argfs*16)", annotation4cgtg.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation4cgtg.getEffects());
 
 		// Insert whole stop codon.
@@ -648,7 +649,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), annotation5cgtg.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation5cgtg.getAnnoLoc().getRank());
 		Assert.assertEquals("6_7insTAAT", annotation5cgtg.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala3*)", annotation5cgtg.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala3*)", annotation5cgtg.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation5cgtg.getEffects());
 	}
 
@@ -665,7 +666,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annoInsertionAfterExon1.getTranscript().getAccession());
 		Assert.assertEquals(0, annoInsertionAfterExon1.getAnnoLoc().getRank());
 		Assert.assertEquals("-70_-70+1insA", annoInsertionAfterExon1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annoInsertionAfterExon1.getProteinChange().toHGVSString()); // XXX
+		Assert.assertEquals("(=)", annoInsertionAfterExon1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER)); // XXX
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT),
 				annoInsertionAfterExon1.getEffects());
@@ -677,7 +678,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annoInsertionAfterExon2.getTranscript().getAccession());
 		Assert.assertEquals(1, annoInsertionAfterExon2.getAnnoLoc().getRank());
 		Assert.assertEquals("690_690+1insA", annoInsertionAfterExon2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annoInsertionAfterExon2.getProteinChange().toHGVSString()); // XXX
+		Assert.assertEquals("?", annoInsertionAfterExon2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER)); // XXX
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annoInsertionAfterExon2.getEffects());
 
@@ -688,7 +689,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annoInsertionAfterExon3.getTranscript().getAccession());
 		Assert.assertEquals(2, annoInsertionAfterExon3.getAnnoLoc().getRank());
 		Assert.assertEquals("932_932+1insA", annoInsertionAfterExon3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annoInsertionAfterExon3.getProteinChange().toHGVSString()); // XXX
+		Assert.assertEquals("?", annoInsertionAfterExon3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER)); // XXX
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annoInsertionAfterExon3.getEffects());
 
@@ -701,7 +702,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annoInsertionBeforeExon1.getTranscript().getAccession());
 		Assert.assertEquals(1, annoInsertionBeforeExon1.getAnnoLoc().getRank());
 		Assert.assertEquals("-69-1_-69insA", annoInsertionBeforeExon1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annoInsertionBeforeExon1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annoInsertionBeforeExon1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.SPLICE_REGION_VARIANT, VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT),
 				annoInsertionBeforeExon1.getEffects());
@@ -713,7 +714,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annoInsertionBeforeExon2.getTranscript().getAccession());
 		Assert.assertEquals(2, annoInsertionBeforeExon2.getAnnoLoc().getRank());
 		Assert.assertEquals("691-1_691insA", annoInsertionBeforeExon2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annoInsertionBeforeExon2.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annoInsertionBeforeExon2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annoInsertionBeforeExon2.getEffects());
 
@@ -724,7 +725,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annoInsertionBeforeExon3.getTranscript().getAccession());
 		Assert.assertEquals(3, annoInsertionBeforeExon3.getAnnoLoc().getRank());
 		Assert.assertEquals("933-1_933insA", annoInsertionBeforeExon3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annoInsertionBeforeExon3.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annoInsertionBeforeExon3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annoInsertionBeforeExon3.getEffects());
 	}
@@ -749,7 +750,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*255dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -773,7 +774,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-37_-36insCTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -852,7 +853,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("769_771dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Phe257dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Phe257dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -894,7 +895,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("439dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Met147Asnfs*8)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Met147Asnfs*8)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -921,7 +922,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("325_327dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Arg109dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Arg109dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -945,7 +946,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("956dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -975,7 +976,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("766_771dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu256_Phe257dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu256_Phe257dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -1002,7 +1003,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("760_771dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu254_Phe257dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu254_Phe257dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -1031,7 +1032,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("424_426dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr142dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr142dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -1061,7 +1062,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("439_444dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asn147_Lys148dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asn147_Lys148dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -1088,7 +1089,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("439_450dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asn147_Lys150dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asn147_Lys150dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -1120,7 +1121,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("949_954dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*319Gluext*2)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*319Gluext*2)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), annotation1.getEffects());
 	}
 
@@ -1153,7 +1154,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("474_476dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu158dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu158dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_INSERTION,
 				VariantEffect.DIRECT_TANDEM_DUPLICATION), annotation1.getEffects());
 	}
@@ -1183,7 +1184,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("628_629insCGAT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu210Profs*61)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu210Profs*61)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1210,7 +1211,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(15, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2265_2266insCC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Tyr756Profs*21)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Tyr756Profs*21)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1239,7 +1240,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("93_94insA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln32Thrfs*39)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln32Thrfs*39)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -1266,7 +1267,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(19, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6318_6319insAGCG", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Trp2107Serfs*6)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Trp2107Serfs*6)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1295,7 +1296,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(19, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6882_6883insCAT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2294_Glu2295insHis)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2294_Glu2295insHis)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION), annotation1.getEffects());
 	}
 
@@ -1322,7 +1323,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(111, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("21594_21595insACTT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val7199Thrfs*8)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val7199Thrfs*8)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1352,7 +1353,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("15_16insTTC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ile5_Lys6insPhe)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ile5_Lys6insPhe)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION), annotation1.getEffects());
 	}
 
@@ -1381,7 +1382,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("8108_8109insTG", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser2704Alafs*301)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser2704Alafs*301)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1408,7 +1409,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6858_6859insCAG", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr2286_Thr2287insGln)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr2286_Thr2287insGln)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION), annotation1.getEffects());
 	}
 
@@ -1435,7 +1436,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("608_609insGACT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln204Thrfs*4)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln204Thrfs*4)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1462,7 +1463,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1147_1148insTGA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Pro383delinsLeuThr)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Pro383delinsLeuThr)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_INSERTION), annotation1.getEffects());
 	}
 
@@ -1492,7 +1493,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("730_731insT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asn244Ilefs*52)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asn244Ilefs*52)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -1517,7 +1518,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1806_1807insATGC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser603Metfs*144)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser603Metfs*144)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1543,7 +1544,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("255_256insAACA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val86Asnfs*13)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val86Asnfs*13)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1570,7 +1571,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("863_864insTCT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu288dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu288dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_INSERTION,
 				VariantEffect.DIRECT_TANDEM_DUPLICATION), annotation1.getEffects());
 	}
@@ -1598,7 +1599,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("118_119insAAAA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly40Glufs*10)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly40Glufs*10)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1625,7 +1626,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("3442_3443insGTA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser1147dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser1147dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_INSERTION,
 				VariantEffect.DIRECT_TANDEM_DUPLICATION), annotation1.getEffects());
 	}
@@ -1653,7 +1654,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("328_329insAA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly110Glufs*51)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly110Glufs*51)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 
@@ -1680,7 +1681,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("286dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu96Profs*16)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu96Profs*16)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
 	}
 
@@ -1711,7 +1712,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1_2insC", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1.getEffects());
 	}
 
@@ -1738,7 +1739,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2_3insA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.START_LOST), annotation1.getEffects());
 	}
 
@@ -1769,7 +1770,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*28_*29insTA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1796,7 +1797,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*18_*21dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1825,7 +1826,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(8, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*5_*6insGACA", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1852,7 +1853,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("660_686dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala225_Asp233dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala225_Asp233dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_INSERTION,
 				VariantEffect.DIRECT_TANDEM_DUPLICATION), annotation1.getEffects());
 	}
@@ -1881,7 +1882,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("589_590insTAAG", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Leu198insLeuSer*)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Leu198insLeuSer*)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.STOP_GAINED),
 				annotation1.getEffects());
 	}
@@ -1907,7 +1908,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(8, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1588-2_1588-1insT", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 
@@ -1919,7 +1920,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation2.getTranscript().getAccession());
 		Assert.assertEquals(8, annotation2.getAnnoLoc().getRank());
 		Assert.assertEquals("1587+1_1587+2insT", annotation2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation2.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation2.getEffects());
 	}
@@ -1946,7 +1947,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(AnnotationLocation.RankType.EXON, annotation1.getAnnoLoc().getRankType());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("126dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
@@ -1973,7 +1974,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(AnnotationLocation.RankType.EXON, annotation1.getAnnoLoc().getRankType());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("73_73+1insG", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
@@ -2000,7 +2001,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(AnnotationLocation.RankType.EXON, annotation1.getAnnoLoc().getRankType());
 		Assert.assertEquals(16, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1429_1431dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser477dup)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser477dup)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.INFRAME_INSERTION, VariantEffect.DIRECT_TANDEM_DUPLICATION),
 				annotation1.getEffects());
@@ -2028,7 +2029,7 @@ public class InsertionAnnotationBuilderTest {
 		Assert.assertEquals(AnnotationLocation.RankType.EXON, annotation1.getAnnoLoc().getRankType());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1250dup", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly418Argfs*?)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly418Argfs*?)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_ELONGATION), annotation1.getEffects());
 	}
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilderTest.java
@@ -10,6 +10,7 @@ import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeVariant;
 import de.charite.compbio.jannovar.annotation.VariantEffect;
 import de.charite.compbio.jannovar.data.ReferenceDictionary;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.reference.GenomePosition;
 import de.charite.compbio.jannovar.reference.GenomeVariant;
 import de.charite.compbio.jannovar.reference.HG19RefDictBuilder;
@@ -115,7 +116,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(1, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("691-11T>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), anno.getEffects());
 
 		// position towards left side of intron
@@ -125,7 +126,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno2.getTranscript().getAccession());
 		Assert.assertEquals(3, anno2.getAnnoLoc().getRank());
 		Assert.assertEquals("1044+11T>A", anno2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), anno2.getEffects());
 	}
 
@@ -137,7 +138,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(10, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("*1T>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
@@ -149,7 +150,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(1, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("-1T>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), anno.getEffects());
 	}
 
@@ -161,7 +162,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(1, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("1A>T", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.START_LOST),
 				anno.getEffects());
 	}
@@ -174,7 +175,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(10, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("2067G>C", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Tyrext*23)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Tyrext*23)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), anno.getEffects());
 	}
 
@@ -186,7 +187,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(10, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("2058T>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Cys686*)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Cys686*)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), anno.getEffects());
 	}
 
@@ -198,7 +199,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(10, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("2067G>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.STOP_RETAINED_VARIANT, VariantEffect.SYNONYMOUS_VARIANT),
 				anno.getEffects());
@@ -212,7 +213,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(0, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("-70+1G>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT, VariantEffect.SPLICE_DONOR_VARIANT),
 				anno.getEffects());
@@ -226,7 +227,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(0, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("-69-1G>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT, VariantEffect.SPLICE_ACCEPTOR_VARIANT),
 				anno.getEffects());
@@ -241,7 +242,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno.getTranscript().getAccession());
 		Assert.assertEquals(1, anno.getAnnoLoc().getRank());
 		Assert.assertEquals("-67G>A", anno.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				anno.getEffects());
@@ -252,7 +253,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno2.getTranscript().getAccession());
 		Assert.assertEquals(6, anno2.getAnnoLoc().getRank());
 		Assert.assertEquals("1225T>G", anno2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Cys409Gly)", anno2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Cys409Gly)", anno2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				anno2.getEffects());
 	}
@@ -267,7 +268,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno1.getTranscript().getAccession());
 		Assert.assertEquals(1, anno1.getAnnoLoc().getRank());
 		Assert.assertEquals("1A>T", anno1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", anno1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", anno1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.START_LOST),
 				anno1.getEffects());
 
@@ -277,7 +278,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno2.getTranscript().getAccession());
 		Assert.assertEquals(1, anno2.getAnnoLoc().getRank());
 		Assert.assertEquals("2T>C", anno2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", anno2.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", anno2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.START_LOST),
 				anno2.getEffects());
 
@@ -287,7 +288,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno3.getTranscript().getAccession());
 		Assert.assertEquals(1, anno3.getAnnoLoc().getRank());
 		Assert.assertEquals("3G>A", anno3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", anno3.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", anno3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.START_LOST),
 				anno3.getEffects());
 
@@ -297,7 +298,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno4.getTranscript().getAccession());
 		Assert.assertEquals(1, anno4.getAnnoLoc().getRank());
 		Assert.assertEquals("4G>T", anno4.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Tyr)", anno4.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Tyr)", anno4.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno4.getEffects());
 
 		GenomeVariant change5 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640673,
@@ -306,7 +307,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno5.getTranscript().getAccession());
 		Assert.assertEquals(1, anno5.getAnnoLoc().getRank());
 		Assert.assertEquals("5A>T", anno5.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp2Val)", anno5.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp2Val)", anno5.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno5.getEffects());
 
 		GenomeVariant change6 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640674,
@@ -315,7 +316,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno6.getTranscript().getAccession());
 		Assert.assertEquals(1, anno6.getAnnoLoc().getRank());
 		Assert.assertEquals("6C>T", anno6.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno6.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno6.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), anno6.getEffects());
 
 		GenomeVariant change7 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640675,
@@ -324,7 +325,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno7.getTranscript().getAccession());
 		Assert.assertEquals(1, anno7.getAnnoLoc().getRank());
 		Assert.assertEquals("7G>T", anno7.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly3Cys)", anno7.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly3Cys)", anno7.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno7.getEffects());
 
 		GenomeVariant change8 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640676,
@@ -333,7 +334,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno8.getTranscript().getAccession());
 		Assert.assertEquals(1, anno8.getAnnoLoc().getRank());
 		Assert.assertEquals("8G>T", anno8.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly3Val)", anno8.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly3Val)", anno8.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno8.getEffects());
 
 		GenomeVariant change9 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640677,
@@ -342,7 +343,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno9.getTranscript().getAccession());
 		Assert.assertEquals(1, anno9.getAnnoLoc().getRank());
 		Assert.assertEquals("9C>G", anno9.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno9.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno9.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), anno9.getEffects());
 
 		GenomeVariant change10 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6640678,
@@ -351,7 +352,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno10.getTranscript().getAccession());
 		Assert.assertEquals(1, anno10.getAnnoLoc().getRank());
 		Assert.assertEquals("10T>A", anno10.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ser4Thr)", anno10.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ser4Thr)", anno10.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno10.getEffects());
 	}
 
@@ -365,7 +366,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno1.getTranscript().getAccession());
 		Assert.assertEquals(10, anno1.getAnnoLoc().getRank());
 		Assert.assertEquals("2066A>G", anno1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Trpext*23)", anno1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Trpext*23)", anno1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno1.getEffects(), ImmutableSortedSet.of(VariantEffect.STOP_LOST));
 
 		GenomeVariant change2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649269,
@@ -374,7 +375,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno2.getTranscript().getAccession());
 		Assert.assertEquals(10, anno2.getAnnoLoc().getRank());
 		Assert.assertEquals("2065T>C", anno2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*689Glnext*23)", anno2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*689Glnext*23)", anno2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno2.getEffects(), ImmutableSortedSet.of(VariantEffect.STOP_LOST));
 
 		GenomeVariant change3 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649268,
@@ -383,7 +384,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno3.getTranscript().getAccession());
 		Assert.assertEquals(10, anno3.getAnnoLoc().getRank());
 		Assert.assertEquals("2064A>T", anno3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno3.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno3.getEffects(), ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT));
 
 		GenomeVariant change4 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649267,
@@ -392,7 +393,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno4.getTranscript().getAccession());
 		Assert.assertEquals(10, anno4.getAnnoLoc().getRank());
 		Assert.assertEquals("2063C>G", anno4.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr688Arg)", anno4.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr688Arg)", anno4.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno4.getEffects(), ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT));
 
 		GenomeVariant change5 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649266,
@@ -401,7 +402,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno5.getTranscript().getAccession());
 		Assert.assertEquals(10, anno5.getAnnoLoc().getRank());
 		Assert.assertEquals("2062A>G", anno5.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr688Ala)", anno5.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr688Ala)", anno5.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno5.getEffects(), ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT));
 
 		GenomeVariant change6 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649265,
@@ -410,7 +411,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno6.getTranscript().getAccession());
 		Assert.assertEquals(10, anno6.getAnnoLoc().getRank());
 		Assert.assertEquals("2061C>T", anno6.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno6.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno6.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno6.getEffects(), ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT));
 
 		GenomeVariant change7 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649264,
@@ -419,7 +420,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno7.getTranscript().getAccession());
 		Assert.assertEquals(10, anno7.getAnnoLoc().getRank());
 		Assert.assertEquals("2060A>G", anno7.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp687Gly)", anno7.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp687Gly)", anno7.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno7.getEffects(), ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT));
 
 		GenomeVariant change8 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649263,
@@ -428,7 +429,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno8.getTranscript().getAccession());
 		Assert.assertEquals(10, anno8.getAnnoLoc().getRank());
 		Assert.assertEquals("2059G>A", anno8.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp687Asn)", anno8.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp687Asn)", anno8.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno8.getEffects(), ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT));
 
 		GenomeVariant change9 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649262,
@@ -437,7 +438,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno9.getTranscript().getAccession());
 		Assert.assertEquals(10, anno9.getAnnoLoc().getRank());
 		Assert.assertEquals("2058T>G", anno9.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Cys686Trp)", anno9.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Cys686Trp)", anno9.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno9.getEffects(), ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT));
 
 		GenomeVariant change10 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6649261,
@@ -446,7 +447,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), anno10.getTranscript().getAccession());
 		Assert.assertEquals(10, anno10.getAnnoLoc().getRank());
 		Assert.assertEquals("2057G>C", anno10.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Cys686Ser)", anno10.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Cys686Ser)", anno10.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(anno10.getEffects(), ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT));
 	}
 
@@ -460,7 +461,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno1.getTranscript().getAccession());
 		Assert.assertEquals(1, anno1.getAnnoLoc().getRank());
 		Assert.assertEquals("1A>T", anno1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", anno1.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", anno1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.START_LOST),
 				anno1.getEffects());
 
@@ -470,7 +471,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno2.getTranscript().getAccession());
 		Assert.assertEquals(1, anno2.getAnnoLoc().getRank());
 		Assert.assertEquals("2T>C", anno2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", anno2.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", anno2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.START_LOST),
 				anno2.getEffects());
 
@@ -480,7 +481,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno3.getTranscript().getAccession());
 		Assert.assertEquals(1, anno3.getAnnoLoc().getRank());
 		Assert.assertEquals("3G>A", anno3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("0?", anno3.getProteinChange().toHGVSString());
+		Assert.assertEquals("0?", anno3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.START_LOST),
 				anno3.getEffects());
 
@@ -490,7 +491,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno4.getTranscript().getAccession());
 		Assert.assertEquals(1, anno4.getAnnoLoc().getRank());
 		Assert.assertEquals("4G>T", anno4.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala2Ser)", anno4.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala2Ser)", anno4.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno4.getEffects());
 
 		GenomeVariant change5 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694493,
@@ -499,7 +500,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno5.getTranscript().getAccession());
 		Assert.assertEquals(1, anno5.getAnnoLoc().getRank());
 		Assert.assertEquals("5C>T", anno5.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala2Val)", anno5.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala2Val)", anno5.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno5.getEffects());
 
 		GenomeVariant change6 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694492,
@@ -508,7 +509,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno6.getTranscript().getAccession());
 		Assert.assertEquals(1, anno6.getAnnoLoc().getRank());
 		Assert.assertEquals("6A>C", anno6.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno6.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno6.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), anno6.getEffects());
 
 		GenomeVariant change7 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694491,
@@ -517,7 +518,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno7.getTranscript().getAccession());
 		Assert.assertEquals(1, anno7.getAnnoLoc().getRank());
 		Assert.assertEquals("7G>A", anno7.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala3Thr)", anno7.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala3Thr)", anno7.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno7.getEffects());
 
 		GenomeVariant change8 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694490,
@@ -526,7 +527,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno8.getTranscript().getAccession());
 		Assert.assertEquals(1, anno8.getAnnoLoc().getRank());
 		Assert.assertEquals("8C>T", anno8.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala3Val)", anno8.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala3Val)", anno8.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno8.getEffects());
 
 		GenomeVariant change9 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694489,
@@ -535,7 +536,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno9.getTranscript().getAccession());
 		Assert.assertEquals(1, anno9.getAnnoLoc().getRank());
 		Assert.assertEquals("9C>G", anno9.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno9.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno9.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), anno9.getEffects());
 
 		GenomeVariant change10 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23694488,
@@ -544,7 +545,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno10.getTranscript().getAccession());
 		Assert.assertEquals(1, anno10.getAnnoLoc().getRank());
 		Assert.assertEquals("10A>G", anno10.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr4Ala)", anno10.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr4Ala)", anno10.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno10.getEffects());
 	}
 
@@ -558,7 +559,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno1.getTranscript().getAccession());
 		Assert.assertEquals(3, anno1.getAnnoLoc().getRank());
 		Assert.assertEquals("1413A>G", anno1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(
 				ImmutableSortedSet.of(VariantEffect.STOP_RETAINED_VARIANT, VariantEffect.SYNONYMOUS_VARIANT),
 				anno1.getEffects());
@@ -569,7 +570,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno2.getTranscript().getAccession());
 		Assert.assertEquals(3, anno2.getAnnoLoc().getRank());
 		Assert.assertEquals("1412A>C", anno2.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*471Serext*9)", anno2.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*471Serext*9)", anno2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), anno2.getEffects());
 
 		GenomeVariant change3 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688463,
@@ -578,7 +579,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno3.getTranscript().getAccession());
 		Assert.assertEquals(3, anno3.getAnnoLoc().getRank());
 		Assert.assertEquals("1411T>A", anno3.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*471Lysext*9)", anno3.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*471Lysext*9)", anno3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), anno3.getEffects());
 
 		GenomeVariant change4 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688464,
@@ -587,7 +588,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno4.getTranscript().getAccession());
 		Assert.assertEquals(3, anno4.getAnnoLoc().getRank());
 		Assert.assertEquals("1410C>G", anno4.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp470Glu)", anno4.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp470Glu)", anno4.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno4.getEffects());
 
 		GenomeVariant change5 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688465,
@@ -596,7 +597,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno5.getTranscript().getAccession());
 		Assert.assertEquals(3, anno5.getAnnoLoc().getRank());
 		Assert.assertEquals("1409A>G", anno5.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp470Gly)", anno5.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp470Gly)", anno5.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno5.getEffects());
 
 		GenomeVariant change6 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688466,
@@ -605,7 +606,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno6.getTranscript().getAccession());
 		Assert.assertEquals(3, anno6.getAnnoLoc().getRank());
 		Assert.assertEquals("1408G>T", anno6.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asp470Tyr)", anno6.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asp470Tyr)", anno6.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno6.getEffects());
 
 		GenomeVariant change7 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688467,
@@ -614,7 +615,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno7.getTranscript().getAccession());
 		Assert.assertEquals(3, anno7.getAnnoLoc().getRank());
 		Assert.assertEquals("1407G>C", anno7.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno7.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno7.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), anno7.getEffects());
 
 		GenomeVariant change8 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688468,
@@ -623,7 +624,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno8.getTranscript().getAccession());
 		Assert.assertEquals(3, anno8.getAnnoLoc().getRank());
 		Assert.assertEquals("1406C>A", anno8.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr469Lys)", anno8.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr469Lys)", anno8.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno8.getEffects());
 
 		GenomeVariant change9 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688469,
@@ -632,7 +633,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno9.getTranscript().getAccession());
 		Assert.assertEquals(3, anno9.getAnnoLoc().getRank());
 		Assert.assertEquals("1405A>G", anno9.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr469Ala)", anno9.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr469Ala)", anno9.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), anno9.getEffects());
 
 		GenomeVariant change10 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 23688470,
@@ -641,7 +642,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoReverse.getAccession(), anno10.getTranscript().getAccession());
 		Assert.assertEquals(3, anno10.getAnnoLoc().getRank());
 		Assert.assertEquals("1404T>C", anno10.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", anno10.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", anno10.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), anno10.getEffects());
 	}
 
@@ -666,7 +667,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1663A>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Lys555*)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Lys555*)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation1.getEffects());
 	}
 
@@ -689,7 +690,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("431G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Trp144*)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Trp144*)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation1.getEffects());
 	}
 
@@ -710,7 +711,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("819T>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Tyr273*)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Tyr273*)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_GAINED), annotation1.getEffects());
 	}
 
@@ -733,7 +734,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(8, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1000T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*334Argext*29)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*334Argext*29)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), annotation1.getEffects());
 	}
 
@@ -756,7 +757,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1134+1T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}
@@ -780,7 +781,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1135T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*379Argext*29)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*379Argext*29)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), annotation1.getEffects());
 	}
 
@@ -803,7 +804,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1171T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(*391Argext*3)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(*391Argext*3)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.STOP_LOST), annotation1.getEffects());
 	}
 
@@ -830,7 +831,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(11, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1060A>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr354Ser)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr354Ser)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
 	}
@@ -854,7 +855,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1090A>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr364Ser)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr364Ser)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
 	}
@@ -878,7 +879,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1099A>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr367Ser)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr367Ser)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
 	}
@@ -902,7 +903,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1150A>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr384Ser)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr384Ser)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
 	}
@@ -926,7 +927,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("166A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr56Ala)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr56Ala)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -949,7 +950,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("166A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr56Ala)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr56Ala)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -970,7 +971,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("70A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr24Ala)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr24Ala)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -993,7 +994,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(16, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1718A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Asn573Ser)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Asn573Ser)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1016,7 +1017,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("308A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu103Gly)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu103Gly)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1038,7 +1039,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("434A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(His145Arg)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(His145Arg)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1061,7 +1062,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("197A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu66Gly)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu66Gly)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1084,7 +1085,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("320A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu107Gly)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu107Gly)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1107,7 +1108,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("515A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu172Gly)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu172Gly)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1130,7 +1131,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("515A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu172Gly)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu172Gly)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1153,7 +1154,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(20, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2756A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Glu919Gly)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Glu919Gly)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1176,7 +1177,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("194A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln65Arg)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln65Arg)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1199,7 +1200,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("229G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ala77Thr)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ala77Thr)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1222,7 +1223,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("47G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Cys16Tyr)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Cys16Tyr)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1245,7 +1246,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(8, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("974C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr325Ile)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr325Ile)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
 	}
@@ -1269,7 +1270,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("7G>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val3Leu)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val3Leu)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1292,7 +1293,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(11, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2653G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Val885Met)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Val885Met)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1315,7 +1316,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("857A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln286Arg)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln286Arg)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1338,7 +1339,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("230A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln77Arg)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln77Arg)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1361,7 +1362,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("17A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(His6Arg)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(His6Arg)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1384,7 +1385,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(8, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("727A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Ile243Val)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Ile243Val)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1407,7 +1408,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("542G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gly181Asp)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gly181Asp)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1430,7 +1431,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("446A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Gln149Arg)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Gln149Arg)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 
@@ -1457,7 +1458,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(11, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1060A>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Thr354Ser)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Thr354Ser)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
 	}
@@ -1481,7 +1482,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("573G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1504,7 +1505,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(20, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2922G>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1527,7 +1528,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-118T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1550,7 +1551,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("207C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1573,7 +1574,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("708C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1596,7 +1597,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1551T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1619,7 +1620,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("750G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1642,7 +1643,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("814C>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1665,7 +1666,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("886C>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1688,7 +1689,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("96C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1711,7 +1712,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("291A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1734,7 +1735,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(24, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("4128T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1757,7 +1758,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("246G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1780,7 +1781,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("99G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1803,7 +1804,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("441T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1826,7 +1827,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(22, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("3030C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1849,7 +1850,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1569T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1872,7 +1873,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("936G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1895,7 +1896,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(27, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1785A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1918,7 +1919,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("171T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1941,7 +1942,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(25, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("3429T>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SYNONYMOUS_VARIANT), annotation1.getEffects());
 	}
 
@@ -1968,7 +1969,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(36, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*51G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -1991,7 +1992,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-74A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2014,7 +2015,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*148C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2037,7 +2038,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-39C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2060,7 +2061,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-10A>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2083,7 +2084,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-37T>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2105,7 +2106,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-3T>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2128,7 +2129,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-49G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2151,7 +2152,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-393T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2174,7 +2175,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-62T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2197,7 +2198,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-33G>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2220,7 +2221,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-725G>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2243,7 +2244,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("336+1G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
@@ -2267,7 +2268,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(19, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("2818-2T>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
@@ -2290,7 +2291,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("225-1G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT,
 				VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annotation1.getEffects());
 	}
@@ -2314,7 +2315,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(8, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6224-1G>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT), annotation1.getEffects());
 	}
@@ -2338,7 +2339,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6332+2T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}
@@ -2362,7 +2363,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6332+3A>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_REGION_VARIANT), annotation1.getEffects());
 	}
@@ -2386,7 +2387,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("6332G>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Arg2111Thr)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Arg2111Thr)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT, VariantEffect.SPLICE_REGION_VARIANT),
 				annotation1.getEffects());
 	}
@@ -2410,7 +2411,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1121+2T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}
@@ -2434,7 +2435,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(9, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1239+2T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}
@@ -2458,7 +2459,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("234+2T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}
@@ -2482,7 +2483,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("135+1T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}
@@ -2506,7 +2507,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("214-2A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT), annotation1.getEffects());
 	}
@@ -2530,7 +2531,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(5, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1074-1G>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT), annotation1.getEffects());
 	}
@@ -2554,7 +2555,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("168+2T>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_DONOR_VARIANT), annotation1.getEffects());
 	}
@@ -2578,7 +2579,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(2, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("337-1G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_ACCEPTOR_VARIANT), annotation1.getEffects());
 	}
@@ -2603,7 +2604,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(36, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("20620683G>A", annotation1.getGenomicNTChange().toHGVSString());
 		Assert.assertEquals("*51G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2822,7 +2823,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(1, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*66C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_EXON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2927,7 +2928,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(13, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1597+24A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
 				annotation1.getEffects());
 	}
@@ -2957,7 +2958,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-58+141C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -2986,7 +2987,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-57-23C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -3016,7 +3017,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*40+38C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -3045,7 +3046,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*41-164T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -3074,7 +3075,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("135+91T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
 				annotation1.getEffects());
 	}
@@ -3104,7 +3105,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("136-7C>T", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_REGION_VARIANT), annotation1.getEffects());
 	}
@@ -3132,7 +3133,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-174-93T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -3159,7 +3160,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(0, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("-175+69A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FIVE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -3188,7 +3189,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*38-90T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -3217,7 +3218,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("*37+65A>G", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.THREE_PRIME_UTR_INTRON_VARIANT), annotation1.getEffects());
 	}
 
@@ -3244,7 +3245,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("620-62T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
 				annotation1.getEffects());
 	}
@@ -3272,7 +3273,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(6, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("619+201T>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(=)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT),
 				annotation1.getEffects());
 	}
@@ -3421,7 +3422,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(10, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("1803-7G>C", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("?", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT,
 				VariantEffect.SPLICE_REGION_VARIANT), annotation1.getEffects());
 	}
@@ -3445,7 +3446,7 @@ public class SNVAnnotationBuilderTest {
 		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
 		Assert.assertEquals(4, annotation1.getAnnoLoc().getRank());
 		Assert.assertEquals("602G>A", annotation1.getCDSNTChange().toHGVSString());
-		Assert.assertEquals("(Arg201His)", annotation1.getProteinChange().toHGVSString());
+		Assert.assertEquals("(Arg201His)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.MISSENSE_VARIANT), annotation1.getEffects());
 	}
 

--- a/jannovar-hgvs/src/main/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinChange.java
+++ b/jannovar-hgvs/src/main/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinChange.java
@@ -30,7 +30,7 @@ public abstract class ProteinChange implements ConvertibleToHGVSString {
 
 	@Override
 	public String toHGVSString() {
-		return toHGVSString(AminoAcidCode.THREE_LETTER);
+		return toHGVSString(AminoAcidCode.ONE_LETTER);
 	}
 
 	/** @return <code>s</code> wrapped in parantheses if not {@link #onlyPredicted} and plain <code>s</code> otherwise. */

--- a/jannovar-hgvs/src/test/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinExtensionTest.java
+++ b/jannovar-hgvs/src/test/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinExtensionTest.java
@@ -32,14 +32,14 @@ public class ProteinExtensionTest {
 
 	@Test
 	public void testNormalExtensionToHGVSString() {
-		Assert.assertEquals("Ala124Thrext*23", normalExtension.toHGVSString());
+		Assert.assertEquals("A124Text*23", normalExtension.toHGVSString());
 		Assert.assertEquals("Ala124Thrext*23", normalExtension.toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals("A124Text*23", normalExtension.toHGVSString(AminoAcidCode.ONE_LETTER));
 	}
 
 	@Test
 	public void testNoTerExtensionToHGVSString() {
-		Assert.assertEquals("Ala124Thrext*?", noTerExtension.toHGVSString());
+		Assert.assertEquals("A124Text*?", noTerExtension.toHGVSString());
 		Assert.assertEquals("Ala124Thrext*?", noTerExtension.toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals("A124Text*?", noTerExtension.toHGVSString(AminoAcidCode.ONE_LETTER));
 	}

--- a/jannovar-hgvs/src/test/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinFrameshiftTest.java
+++ b/jannovar-hgvs/src/test/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinFrameshiftTest.java
@@ -39,21 +39,21 @@ public class ProteinFrameshiftTest {
 
 	@Test
 	public void testFullFrameshiftToHGVSString() {
-		Assert.assertEquals("Ala124Thrfs*23", fullFrameshift.toHGVSString());
+		Assert.assertEquals("A124Tfs*23", fullFrameshift.toHGVSString());
 		Assert.assertEquals("Ala124Thrfs*23", fullFrameshift.toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals("A124Tfs*23", fullFrameshift.toHGVSString(AminoAcidCode.ONE_LETTER));
 	}
 
 	@Test
 	public void testNoTerFrameshiftToHGVSString() {
-		Assert.assertEquals("Ala124Thrfs*?", noTerFrameshift.toHGVSString());
+		Assert.assertEquals("A124Tfs*?", noTerFrameshift.toHGVSString());
 		Assert.assertEquals("Ala124Thrfs*?", noTerFrameshift.toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals("A124Tfs*?", noTerFrameshift.toHGVSString(AminoAcidCode.ONE_LETTER));
 	}
 
 	@Test
 	public void testShortFrameshiftToHGVSString() {
-		Assert.assertEquals("Ala124fs", shortFrameshift.toHGVSString());
+		Assert.assertEquals("A124fs", shortFrameshift.toHGVSString());
 		Assert.assertEquals("Ala124fs", shortFrameshift.toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assert.assertEquals("A124fs", shortFrameshift.toHGVSString(AminoAcidCode.ONE_LETTER));
 	}

--- a/jannovar-hgvs/src/test/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinSubstitutionTest.java
+++ b/jannovar-hgvs/src/test/java/de/charite/compbio/jannovar/hgvs/protein/change/ProteinSubstitutionTest.java
@@ -32,7 +32,7 @@ public class ProteinSubstitutionTest {
 	public void testToHGVSString() {
 		Assert.assertEquals("(A124G)", sub1.toHGVSString(AminoAcidCode.ONE_LETTER));
 		Assert.assertEquals("(Ala124Gly)", sub1.toHGVSString(AminoAcidCode.THREE_LETTER));
-		Assert.assertEquals("(Ala124Gly)", sub1.toHGVSString());
+		Assert.assertEquals("(A124G)", sub1.toHGVSString());
 	}
 
 	@Test

--- a/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantContextAnnotator.java
+++ b/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantContextAnnotator.java
@@ -23,6 +23,7 @@ import de.charite.compbio.jannovar.annotation.builders.AnnotationBuilderOptions;
 import de.charite.compbio.jannovar.data.Chromosome;
 import de.charite.compbio.jannovar.data.JannovarData;
 import de.charite.compbio.jannovar.data.ReferenceDictionary;
+import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.reference.GenomePosition;
 import de.charite.compbio.jannovar.reference.GenomeVariant;
 import de.charite.compbio.jannovar.reference.PositionType;
@@ -55,6 +56,11 @@ public final class VariantContextAnnotator {
 		 * <code>true</code>
 		 */
 		private final boolean oneAnnotationOnly;
+		
+		/**
+		 * HGVS protein output in three or one letter
+		 */
+		private final AminoAcidCode aminoAcidCode;
 
 		/** whether or not to escape values in the ANN field (defaults to <code>true</code>) */
 		private final boolean escapeAnnField;
@@ -76,6 +82,7 @@ public final class VariantContextAnnotator {
 		 */
 		public Options() {
 			oneAnnotationOnly = true;
+			aminoAcidCode = AminoAcidCode.ONE_LETTER;
 			escapeAnnField = true;
 			nt3PrimeShifting = true;
 			offTargetFilterEnabled = false;
@@ -88,24 +95,29 @@ public final class VariantContextAnnotator {
 		 * constructor using fields
 		 * 
 		 * @param oneAnnotationOnly
-		 *            Whether or not to trim each annotation list to the first (one with highest putative impact),
-		 *            defaults to <code>true</code>
+		 *            Whether or not to trim each annotation list to the first (one with
+		 *            highest putative impact), defaults to <code>true</code>
+		 * @param code
+		 *            HGVS protein output in three or one letter
 		 * @param escapeAnnField
-		 *            whether or not to escape values in the ANN field (defaults to <code>true</code>)
-		 * @param nt3PrimeShifting
-		 *            whether or not to perform shifting towards the 3' end of the transcript (defaults to
+		 *            whether or not to escape values in the ANN field (defaults to
 		 *            <code>true</code>)
+		 * @param nt3PrimeShifting
+		 *            whether or not to perform shifting towards the 3' end of the
+		 *            transcript (defaults to <code>true</code>)
 		 * @param offTargetFilterEnabled
 		 *            whether or not off target filter application is abled
 		 * @param offTargetFilterUtrIsOffTarget
 		 *            whether or not to count UTR as off-target
 		 * @param offTargetFilterIntronicSpliceIsOffTarget
-		 *            whether or not to to count non-consensus intronic splicing as off-target
+		 *            whether or not to to count non-consensus intronic splicing as
+		 *            off-target
 		 */
-		public Options(boolean oneAnnotationOnly, boolean escapeAnnField, boolean nt3PrimeShifting,
+		public Options(boolean oneAnnotationOnly, AminoAcidCode code, boolean escapeAnnField, boolean nt3PrimeShifting,
 				boolean offTargetFilterEnabled, boolean offTargetFilterUtrIsOffTarget,
 				boolean offTargetFilterIntronicSpliceIsOffTarget) {
 			this.oneAnnotationOnly = oneAnnotationOnly;
+			this.aminoAcidCode = code;
 			this.escapeAnnField = escapeAnnField;
 			this.nt3PrimeShifting = nt3PrimeShifting;
 			this.offTargetFilterEnabled = offTargetFilterEnabled;
@@ -344,7 +356,7 @@ public final class VariantContextAnnotator {
 
 					if (!options.oneAnnotationOnly || annotations.isEmpty()) {
 						final String alt = vc.getAlternateAllele(alleleID).getBaseString();
-						annotations.add(ann.toVCFAnnoString(alt));
+						annotations.add(ann.toVCFAnnoString(alt, options.aminoAcidCode));
 					}
 				}
 			}


### PR DESCRIPTION
* Enables the option to represent HGVS in one or three AA letters in the VCF annotator.
* Default is now One letter!
* Option `--3-letter-amino-acids` works now as expected