### PR TITLE
further modifications to PR #371 (to address #353 and another format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### jannovar-cli
 
 * Fixing annotation with Polyphen prediction (data type)
+* Support for [RefSeq GRCh37.p13 interim release](https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_)
 
 ### overall
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 * Changing HTSJDK version to 2.14.3
 * Using the one letter amino acid code in HGVS representation as default (changes in core, hgvs, htsjdk and cli). Now the cli option `--3-letter-amino-acids` works as expected.
 
+### jannovar-cli
+
+* Support for [RefSeq GRCh37.p13 interim release](https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_)
+* Support of new RefSeq headers
+* Using RefSeq GRCh38.p12 annotation instead of GRCh38.p7
+
 ### jannovar-vardbs
 
 * Replacing whitespace with string when annotating from TSV file.
@@ -20,7 +26,6 @@
 ### jannovar-cli
 
 * Fixing annotation with Polyphen prediction (data type)
-* Support for [RefSeq GRCh37.p13 interim release](https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_)
 
 ### overall
 

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/download/JannovarDownloadOptions.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/download/JannovarDownloadOptions.java
@@ -12,12 +12,13 @@ import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 
 /**
  * Configuration for the <tt>download</tt> command
- * 
+ *
  * @author <a href="mailto:manuel.holtgrewe@bihealth.de">Manuel Holtgrewe</a>
  */
 public class JannovarDownloadOptions extends JannovarDBOptions {
@@ -30,7 +31,7 @@ public class JannovarDownloadOptions extends JannovarDBOptions {
 
 	/**
 	 * Setup {@link ArgumentParser}
-	 * 
+	 *
 	 * @param subParsers
 	 *            {@link Subparsers} to setup
 	 */
@@ -42,18 +43,18 @@ public class JannovarDownloadOptions extends JannovarDBOptions {
 				throw new UncheckedJannovarException("Could not parse command line", e);
 			}
 		};
-		
+
 		Subparser subParser = subParsers.addParser("download", true).help("download transcript databases")
 				.setDefault("cmd", handler);
 		subParser.description("Download transcript database");
-		
+
 		ArgumentGroup requiredGroup = subParser.addArgumentGroup("Required arguments");
 		requiredGroup.addArgument("-d", "--database").help("Name of database to download, can be given multiple times")
 				.setDefault(new ArrayList<String>()).action(Arguments.append()).required(true);
 
 		ArgumentGroup optionalGroup = subParser.addArgumentGroup("Optional Arguments");
 		optionalGroup.addArgument("-s", "--data-source-list").help("INI file with data source list")
-				.setDefault("bundle:///default_sources.ini").action(Arguments.append());
+				.setDefault(new ArrayList<String>(Arrays.asList("bundle:///default_sources.ini"))).action(Arguments.append());
 		optionalGroup.addArgument("--download-dir").help("Path to download directory").setDefault("data");
 
 		JannovarBaseOptions.setupParser(subParser);

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/download/JannovarDownloadOptions.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/download/JannovarDownloadOptions.java
@@ -1,11 +1,5 @@
 package de.charite.compbio.jannovar.cmd.download;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.BiFunction;
-
-import com.google.common.collect.Lists;
-
 import de.charite.compbio.jannovar.UncheckedJannovarException;
 import de.charite.compbio.jannovar.cmd.CommandLineParsingException;
 import de.charite.compbio.jannovar.cmd.JannovarBaseOptions;
@@ -16,6 +10,10 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
 
 /**
  * Configuration for the <tt>download</tt> command
@@ -55,7 +53,7 @@ public class JannovarDownloadOptions extends JannovarDBOptions {
 
 		ArgumentGroup optionalGroup = subParser.addArgumentGroup("Optional Arguments");
 		optionalGroup.addArgument("-s", "--data-source-list").help("INI file with data source list")
-				.setDefault(Lists.newArrayList("bundle:///default_sources.ini")).action(Arguments.append());
+				.setDefault("bundle:///default_sources.ini").action(Arguments.append());
 		optionalGroup.addArgument("--download-dir").help("Path to download directory").setDefault("data");
 
 		JannovarBaseOptions.setupParser(subParser);

--- a/jannovar-cli/src/main/resources/default_sources.ini
+++ b/jannovar-cli/src/main/resources/default_sources.ini
@@ -155,6 +155,17 @@ chrToAccessions.format=chr_accessions
 gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
 rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
 
+; HG19 from RefSeq interim alignment, only curated (see https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_)
+[hg19/refseq_interim]
+type=refseq
+alias=MT,M,chrM
+onlyCurated=true
+chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/chromInfo.txt.gz
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/Assembled_chromosomes/chr_accessions_GRCh37.p13
+chrToAccessions.format=chr_accessions
+gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
+rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
+
 ; ---------------------------------------------------------------------------
 ; hg38/GRCh38
 ; ---------------------------------------------------------------------------
@@ -187,9 +198,9 @@ cdna=ftp://ftp.ensembl.org/pub/release-78/fasta/homo_sapiens/cdna/Homo_sapiens.G
 type=refseq
 alias=MT,M,chrM
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p7
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
-gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p7_top_level.gff3.gz
+gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p12_top_level.gff3.gz
 rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
 
 ; HG38 from RefSeq (only curated data sets)
@@ -198,9 +209,9 @@ type=refseq
 alias=MT,M,chrM
 onlyCurated=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p7
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
-gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p7_top_level.gff3.gz
+gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p12_top_level.gff3.gz
 rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
 
 ; ---------------------------------------------------------------------------

--- a/jannovar-cli/src/main/resources/default_sources.ini
+++ b/jannovar-cli/src/main/resources/default_sources.ini
@@ -156,7 +156,7 @@ gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/i
 rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
 
 ; HG19 from RefSeq interim alignment, only curated (see https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_)
-[hg19/refseq_interim]
+[hg19/refseq_interim_curated]
 type=refseq
 alias=MT,M,chrM
 onlyCurated=true

--- a/jannovar-cli/src/main/resources/default_sources.ini
+++ b/jannovar-cli/src/main/resources/default_sources.ini
@@ -145,6 +145,16 @@ chrToAccessions.format=chr_accessions
 gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/GFF/ref_GRCh37.p13_top_level.gff3.gz
 rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/RNA/rna.fa.gz
 
+; HG19 from RefSeq interim alignment (see https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_)
+[hg19/refseq_interim]
+type=refseq
+alias=MT,M,chrM
+chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/chromInfo.txt.gz
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/Assembled_chromosomes/chr_accessions_GRCh37.p13
+chrToAccessions.format=chr_accessions
+gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
+rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
+
 ; ---------------------------------------------------------------------------
 ; hg38/GRCh38
 ; ---------------------------------------------------------------------------

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/DataSourceFactory.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/DataSourceFactory.java
@@ -1,16 +1,14 @@
 package de.charite.compbio.jannovar.datasource;
 
+import com.google.common.collect.ImmutableList;
+import org.ini4j.Ini;
+import org.ini4j.Profile.Section;
+
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-
-import org.ini4j.Ini;
-import org.ini4j.InvalidFileFormatException;
-import org.ini4j.Profile.Section;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  * Factory class that allows the construction of {@link DataSource} objects as configured in INI files.
@@ -35,7 +33,7 @@ final public class DataSourceFactory {
 	public DataSourceFactory(DatasourceOptions options, List<String> iniFilePaths) throws InvalidDataSourceException {
 		this.options = options;
 
-		ImmutableList.Builder<Ini> inisBuilder = new ImmutableList.Builder<Ini>();
+		ImmutableList.Builder<Ini> inisBuilder = new ImmutableList.Builder<>();
 		for (String iniFilePath : iniFilePaths) {
 			InputStream is;
 			final String BUNDLE_PREFIX = "bundle://";
@@ -55,8 +53,6 @@ final public class DataSourceFactory {
 			Ini ini = new Ini();
 			try {
 				ini.load(is);
-			} catch (InvalidFileFormatException e) {
-				throw new InvalidDataSourceException("Problem loading data source file.", e);
 			} catch (IOException e) {
 				throw new InvalidDataSourceException("Problem loading data source file.", e);
 			}
@@ -69,7 +65,7 @@ final public class DataSourceFactory {
 	 * @return list of data source names
 	 */
 	public ImmutableList<String> getNames() {
-		ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>();
+		ImmutableList.Builder<String> builder = new ImmutableList.Builder<>();
 		for (Ini ini : inis)
 			for (String name : ini.keySet())
 				if (ini.get(name).get("type") != null)

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/gtfgff/FeatureRecord.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/gtfgff/FeatureRecord.java
@@ -48,7 +48,7 @@ public final class FeatureRecord implements Comparable<FeatureRecord> {
 	private final int phase;
 
 	/** Record's attributes */
-	private ImmutableMap<String, String> attributes;
+	private final ImmutableMap<String, String> attributes;
 
 	/**
 	 * Initialize the <code>GFFRecord</code>
@@ -68,10 +68,6 @@ public final class FeatureRecord implements Comparable<FeatureRecord> {
 
 	public ImmutableMap<String, String> getAttributes() {
 		return attributes;
-	}
-
-	public void setAttributes(ImmutableMap<String, String> attributes) {
-		this.attributes = attributes;
 	}
 
 	public String getSeqID() {

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
@@ -63,6 +63,7 @@ public enum RefSeqFastaRecordIdFormat {
 			return of(tokens.get(DEFAULT_FORMAT_ACCESSION_INDEX));
 		case INTERIM_RELEASE_201701_FORMAT:
 			return of(recordId);
+		default:
 		case UNKNOWN_FORMAT:
 			LOGGER.error("ID {} in FASTA did not have any of the expected formats.", recordId);
 		}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
@@ -1,0 +1,71 @@
+package de.charite.compbio.jannovar.impl.parse.refseq;
+
+import com.google.common.base.Splitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+/**
+ * RefSeq import files may have different formats in their FASTA record IDs.
+ */
+public enum RefSeqFastaRecordIdFormat {
+
+	DEFAULT_FORMAT,
+
+	INTERIM_RELEASE_201701_FORMAT,
+
+	UNKNOWN_FORMAT;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(RefSeqFastaRecordIdFormat.class);
+
+	private static final String EXPECTED_PREFIX_DEFAULT_FORMAT = "gi|";
+
+	private static final int DEFAULT_FORMAT_ACCESSION_INDEX = 3;
+
+	private static final int DEFAULT_FORMAT_EXPECTED_RECORD_ID_ELEMENTS = 5;
+
+	/**
+	 * Number of digits depends on the prefix (here we allow 'NM_' and 'NR_', as well as non-curated 'XM_' and 'X_R').
+	 *
+	 * @see <a href="https://www.ncbi.nlm.nih.gov/books/NBK21091/table/ch18.T.refseq_accession_numbers_and_mole/?report=objectonly">NCBI documentation</a>
+	 */
+	private static final String NCBI_ID_REGEXP = "[NX][MR]_([0-9]+)\\.[0-9]+";
+
+	private static final Pattern NCBI_ID = Pattern.compile(NCBI_ID_REGEXP);
+
+	public static RefSeqFastaRecordIdFormat detect(String recordId) {
+		if (recordId == null) {
+			return UNKNOWN_FORMAT;
+		}
+		if (recordId.startsWith(EXPECTED_PREFIX_DEFAULT_FORMAT)) {
+			return DEFAULT_FORMAT;
+		}
+		if (NCBI_ID.matcher(recordId).matches()) {
+			return INTERIM_RELEASE_201701_FORMAT;
+		}
+		return UNKNOWN_FORMAT;
+	}
+
+	public static Optional<String> extractAccession(String recordId) {
+		switch (detect(recordId)) {
+		case DEFAULT_FORMAT:
+			final List<String> tokens = Splitter.on('|').splitToList(recordId);
+			if (tokens.size() != DEFAULT_FORMAT_EXPECTED_RECORD_ID_ELEMENTS) {
+				LOGGER.error("ID {} in FASTA did not have 4 fields", recordId);
+				return empty();
+			}
+			return of(tokens.get(DEFAULT_FORMAT_ACCESSION_INDEX));
+		case INTERIM_RELEASE_201701_FORMAT:
+			return of(recordId);
+		case UNKNOWN_FORMAT:
+			LOGGER.error("ID {} in FASTA did not have any of the expected formats.", recordId);
+		}
+		return empty();
+	}
+}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
@@ -33,8 +33,8 @@ public enum RefSeqFastaRecordIdFormat {
 	 */
 	private static final Pattern NCBI_ID = Pattern.compile("[NX][MR]_([0-9]+)\\.[0-9]+");
 
-	private final String expectedPrefix;
-	private final int accessionIndex, expectedIdElementCount;
+	private String expectedPrefix;
+	private int accessionIndex, expectedIdElementCount;
 
 	RefSeqFastaRecordIdFormat(String expectedPrefix, int accessionIndex, int expectedIdElementCount) {
 		this.expectedPrefix = expectedPrefix;

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
@@ -73,4 +73,14 @@ public enum RefSeqFastaRecordIdFormat {
 		}
 		return of(tokens.get(format.accessionIndex));
 	}
+	
+	public String getPrefix() {
+		return this.expectedPrefix;
+	}
+	public int getAcdcessionIndex() {
+		return this.accessionIndex;
+	}
+	public int getIDElementCount() {
+		return this.expectedIdElementCount;
+	}
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormat.java
@@ -33,8 +33,9 @@ public enum RefSeqFastaRecordIdFormat {
 	 */
 	private static final Pattern NCBI_ID = Pattern.compile("[NX][MR]_([0-9]+)\\.[0-9]+");
 
-	private String expectedPrefix;
-	private int accessionIndex, expectedIdElementCount;
+	private final String expectedPrefix;
+	private final int accessionIndex;
+	private final int expectedIdElementCount;
 
 	RefSeqFastaRecordIdFormat(String expectedPrefix, int accessionIndex, int expectedIdElementCount) {
 		this.expectedPrefix = expectedPrefix;

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
@@ -1,25 +1,10 @@
 package de.charite.compbio.jannovar.impl.parse.refseq;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
-import org.ini4j.Profile.Section;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-
 import de.charite.compbio.jannovar.JannovarException;
 import de.charite.compbio.jannovar.UncheckedJannovarException;
 import de.charite.compbio.jannovar.data.ReferenceDictionary;
@@ -36,6 +21,20 @@ import de.charite.compbio.jannovar.reference.GenomeInterval;
 import de.charite.compbio.jannovar.reference.Strand;
 import de.charite.compbio.jannovar.reference.TranscriptModel;
 import de.charite.compbio.jannovar.reference.TranscriptModelBuilder;
+import org.ini4j.Profile.Section;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Parsing of RefSeq GFF3 files
@@ -137,13 +136,11 @@ public class RefSeqParser implements TranscriptParser {
 		FASTARecord record;
 		try {
 			while ((record = fastaParser.next()) != null) {
-				final List<String> tokens = Splitter.on('|').splitToList(record.getID());
-				if (tokens.size() != 5) {
-					LOGGER.error("ID {} in FASTA did not have 4 fields", new Object[] { record.getID() });
+				Optional<String> accessionOpt = RefSeqFastaRecordIdFormat.extractAccession(record.getID());
+				if(!accessionOpt.isPresent()) {
 					continue;
 				}
-
-				final String accession = tokens.get(3);
+				String accession = accessionOpt.get();
 				final TranscriptModelBuilder builder = txMap.get(accession);
 				if (builder == null) {
 					// This is not a warning as we observed this for some records regularly

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
@@ -53,13 +53,13 @@ public class RefSeqParser implements TranscriptParser {
 	/**
 	 * Path to the {@link ReferenceDictionary} to use for name/id and id/length mapping
 	 */
-	private final ReferenceDictionary refDict;
+	private ReferenceDictionary refDict;
 
 	/** Path to directory where the to-be-parsed files live */
-	private final String basePath;
+	private String basePath;
 
 	/** INI {@link Section} from the configuration. */
-	private final Section iniSection;
+	private Section iniSection;
 
 	/**
 	 * @param refDict

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormatTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormatTest.java
@@ -1,0 +1,34 @@
+package de.charite.compbio.jannovar.impl.parse.refseq;
+
+import org.junit.Test;
+
+import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.DEFAULT_FORMAT;
+import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.INTERIM_RELEASE_201701_FORMAT;
+import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.UNKNOWN_FORMAT;
+import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.detect;
+import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.extractAccession;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link RefSeqFastaRecordIdFormat}. */
+public class RefSeqFastaRecordIdFormatTest {
+
+	@Test
+	public void detectOk() throws Exception {
+		assertEquals(UNKNOWN_FORMAT, detect(null));
+		assertEquals(UNKNOWN_FORMAT, detect(""));
+		assertEquals(DEFAULT_FORMAT, detect("gi|66932946|ref|NM_000014.4| Homo sapiens alpha-2-macroglobulin (A2M), mRNA"));
+		assertEquals(INTERIM_RELEASE_201701_FORMAT, detect("NM_000014.5"));
+		assertEquals(UNKNOWN_FORMAT, detect("unknown"));
+	}
+
+	@Test
+	public void extractAccessionOk() {
+		assertEquals(empty(), extractAccession(null));
+		assertEquals(empty(), extractAccession(""));
+		assertEquals(of("NM_000014.4"), extractAccession("gi|66932946|ref|NM_000014.4|"));
+		assertEquals(of("NM_000014.4"), extractAccession("NM_000014.4"));
+	}
+
+}

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormatTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqFastaRecordIdFormatTest.java
@@ -2,11 +2,7 @@ package de.charite.compbio.jannovar.impl.parse.refseq;
 
 import org.junit.Test;
 
-import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.DEFAULT_FORMAT;
-import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.INTERIM_RELEASE_201701_FORMAT;
-import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.UNKNOWN_FORMAT;
-import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.detect;
-import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.extractAccession;
+import static de.charite.compbio.jannovar.impl.parse.refseq.RefSeqFastaRecordIdFormat.*;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.junit.Assert.assertEquals;
@@ -18,8 +14,8 @@ public class RefSeqFastaRecordIdFormatTest {
 	public void detectOk() throws Exception {
 		assertEquals(UNKNOWN_FORMAT, detect(null));
 		assertEquals(UNKNOWN_FORMAT, detect(""));
-		assertEquals(DEFAULT_FORMAT, detect("gi|66932946|ref|NM_000014.4| Homo sapiens alpha-2-macroglobulin (A2M), mRNA"));
-		assertEquals(INTERIM_RELEASE_201701_FORMAT, detect("NM_000014.5"));
+		assertEquals(GI_REF_FORMAT, detect("gi|66932946|ref|NM_000014.4| Homo sapiens alpha-2-macroglobulin (A2M), mRNA"));
+		assertEquals(ACCESSION_FORMAT, detect("NM_000014.5"));
 		assertEquals(UNKNOWN_FORMAT, detect("unknown"));
 	}
 
@@ -28,6 +24,7 @@ public class RefSeqFastaRecordIdFormatTest {
 		assertEquals(empty(), extractAccession(null));
 		assertEquals(empty(), extractAccession(""));
 		assertEquals(of("NM_000014.4"), extractAccession("gi|66932946|ref|NM_000014.4|"));
+		assertEquals(of("NM_000014.4"), extractAccession("ref|NM_000014.4|"));
 		assertEquals(of("NM_000014.4"), extractAccession("NM_000014.4"));
 	}
 

--- a/manual/datasource.rst
+++ b/manual/datasource.rst
@@ -137,8 +137,8 @@ Below is an example for the Ensemble data source for human release hg19.
 RefSeq Data Sources
 -------------------
 
-When selecting the ``ensembl`` data source type then you have to pass the transcript definition GFF URL to ``gff`` and the RNA FASTA file to ``rna``.
-Below is an example for the RefSeqe data source for human release hg19.
+When selecting the ``refseq`` data source type then you have to pass the transcript definition GFF URL to ``gff`` and the RNA FASTA file to ``rna``.
+Below is an example for the RefSeq data source for human release hg19.
 
 .. code-block:: ini
     :emphasize-lines: 7-8
@@ -167,6 +167,21 @@ You can do this by setting ``onlyCurated`` to ``true``:
     chrToAccessions.format=chr_accessions
     gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/GFF/ref_GRCh37.p13_top_level.gff3.gz
     rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/RNA/rna.fa.gz
+
+Additionally, ``hg19/refseq_interim`` defines the URLS for the
+`GRCh37.p13 interim release of the RefSeq data <https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_>`:
+
+.. code-block:: ini
+    :emphasize-lines: 4
+
+    [hg19/refseq_interim]
+    type=refseq
+    alias=MT,M,chrM
+    chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/chromInfo.txt.gz
+    chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/Assembled_chromosomes/chr_accessions_GRCh37.p13
+    chrToAccessions.format=chr_accessions
+    gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
+    rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
 
 UCSC Data Sources
 -----------------


### PR DESCRIPTION
NCBI Annotation release 109 has yet another format (that goes back to having something like `ref|NM_01321.4|` but without the corresponding `gi|` part. This will be required to use the latest annotation files from NCBI (as of about 20180331).

This PR accounts for that possibility, and also reverts the `-s` option to an appendable array rather than a string (as requested in #371). It builds upon #371 by @roland-ewald -- I hope I got the protocol correct for making this PR.