### PR TITLE
fix for GRCh38

### DIFF
--- a/jannovar-cli/src/main/resources/default_sources.ini
+++ b/jannovar-cli/src/main/resources/default_sources.ini
@@ -154,7 +154,7 @@ rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/
 type=ucsc
 alias=MT,M,chrM
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p7
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/Assembled_chromosomes/chr_accessions_GRCh38.p7
 chrToAccessions.format=chr_accessions
 knownCanonical=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/knownCanonical.txt.gz
 knownGene=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz
@@ -167,7 +167,7 @@ knownToLocusLink=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/knownTo
 type=ensembl
 alias=MT,M,chrM
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p7
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/Assembled_chromosomes/chr_accessions_GRCh38.p7
 chrToAccessions.format=chr_accessions
 gtf=ftp://ftp.ensembl.org/pub/release-78/gtf/homo_sapiens/Homo_sapiens.GRCh38.78.gtf.gz
 cdna=ftp://ftp.ensembl.org/pub/release-78/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh38.cdna.all.fa.gz
@@ -177,10 +177,10 @@ cdna=ftp://ftp.ensembl.org/pub/release-78/fasta/homo_sapiens/cdna/Homo_sapiens.G
 type=refseq
 alias=MT,M,chrM
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p7
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/Assembled_chromosomes/chr_accessions_GRCh38.p7
 chrToAccessions.format=chr_accessions
-gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p7_top_level.gff3.gz
-rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
+gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/GFF/ref_GRCh38.p7_top_level.gff3.gz
+rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/RNA/rna.fa.gz
 
 ; HG38 from RefSeq (only curated data sets)
 [hg38/refseq_curated]
@@ -188,10 +188,10 @@ type=refseq
 alias=MT,M,chrM
 onlyCurated=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p7
+chrToAccessions=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/Assembled_chromosomes/chr_accessions_GRCh38.p7
 chrToAccessions.format=chr_accessions
-gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p7_top_level.gff3.gz
-rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
+gff=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/GFF/ref_GRCh38.p7_top_level.gff3.gz
+rna=ftp://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.108/RNA/rna.fa.gz
 
 ; ---------------------------------------------------------------------------
 ; mm9


### PR DESCRIPTION
fixed the path to the GRCh38.p7 release for NCBI data (to archive), since the current dataset (GRCh38.p13) does not seem too work