### PR TITLE
Add check to GenomeInterval, GenomePosition and GenomeVariant withStr…

### DIFF
--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/Annotation.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/Annotation.java
@@ -1,10 +1,12 @@
 package de.charite.compbio.jannovar.annotation;
 
 import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Set;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSortedSet;
 
+import com.google.common.collect.Sets;
 import de.charite.compbio.jannovar.Immutable;
 import de.charite.compbio.jannovar.hgvs.AminoAcidCode;
 import de.charite.compbio.jannovar.hgvs.nts.change.NucleotideChange;
@@ -26,6 +28,9 @@ import de.charite.compbio.jannovar.reference.VariantDescription;
  */
 @Immutable
 public final class Annotation implements VariantDescription, Comparable<Annotation> {
+
+	private static final Set<VariantEffect> EMPTY_VARIANT_EFFECTS = Sets.immutableEnumSet(EnumSet.noneOf(VariantEffect.class));
+	private static final Set<AnnotationMessage> EMPTY_ANNOTATION_MESSAGES = Sets.immutableEnumSet(EnumSet.noneOf(AnnotationMessage.class));
 
 	/**
 	 * This line is added to the output of a VCF file annotated by Jannovar and describes the new field for the INFO
@@ -52,10 +57,10 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 	private final GenomeVariant change;
 
 	/** variant types, sorted by internal pathogenicity score */
-	private final ImmutableSortedSet<VariantEffect> effects;
+	private final Set<VariantEffect> effects;
 
 	/** errors and warnings */
-	private final ImmutableSortedSet<AnnotationMessage> messages;
+	private final Set<AnnotationMessage> messages;
 
 	/** location of the annotation, <code>null</code> if not even nearby a {@link TranscriptModel} */
 	private final AnnotationLocation annoLoc;
@@ -109,7 +114,7 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 			AnnotationLocation annoLoc, NucleotideChange genomicNTChange, NucleotideChange cdsNTChange,
 			ProteinChange proteinChange) {
 		this(transcript, change, effects, annoLoc, genomicNTChange, cdsNTChange, proteinChange,
-				ImmutableSortedSet.<AnnotationMessage> of());
+			EMPTY_ANNOTATION_MESSAGES);
 	}
 
 	/**
@@ -137,19 +142,15 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 	public Annotation(TranscriptModel transcript, GenomeVariant change, Collection<VariantEffect> varTypes,
 			AnnotationLocation annoLoc, NucleotideChange genomicNTChange, NucleotideChange cdsNTChange,
 			ProteinChange proteinChange, Collection<AnnotationMessage> messages) {
-		if (change != null)
-			change = change.withStrand(Strand.FWD); // enforce forward strand
-		this.change = change;
-		if (varTypes == null)
-			this.effects = ImmutableSortedSet.<VariantEffect> of();
-		else
-			this.effects = ImmutableSortedSet.copyOf(varTypes);
+		// enforce forward strand
+		this.change = change == null ? null : change.withStrand(Strand.FWD);
+		this.effects = varTypes == null ? EMPTY_VARIANT_EFFECTS : Sets.immutableEnumSet(varTypes);
 		this.annoLoc = annoLoc;
 		this.genomicNTChange = genomicNTChange;
 		this.cdsNTChange = cdsNTChange;
 		this.proteinChange = proteinChange;
 		this.transcript = transcript;
-		this.messages = ImmutableSortedSet.copyOf(messages);
+		this.messages = Sets.immutableEnumSet(messages);
 	}
 
 	/** @return the annotated {@link GenomeVariant} */
@@ -158,12 +159,12 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 	}
 
 	/** @return variant types, sorted by internal pathogenicity score */
-	public ImmutableSortedSet<VariantEffect> getEffects() {
+	public Set<VariantEffect> getEffects() {
 		return effects;
 	}
 
 	/** @return errors and warnings */
-	public ImmutableSortedSet<AnnotationMessage> getMessages() {
+	public Set<AnnotationMessage> getMessages() {
 		return messages;
 	}
 
@@ -245,7 +246,7 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 	public PutativeImpact getPutativeImpact() {
 		if (effects.isEmpty())
 			return null;
-		VariantEffect worst = effects.first();
+		VariantEffect worst = effects.iterator().next();
 		for (VariantEffect vt : effects)
 			if (worst.getImpact().compareTo(vt.getImpact()) > 0)
 				worst = vt;
@@ -333,7 +334,7 @@ public final class Annotation implements VariantDescription, Comparable<Annotati
 	public VariantEffect getMostPathogenicVarType() {
 		if (effects.isEmpty())
 			return null;
-		return effects.first();
+		return effects.iterator().next();
 	}
 
 	@Override

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VCFAnnotationData.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VCFAnnotationData.java
@@ -1,5 +1,7 @@
 package de.charite.compbio.jannovar.annotation;
 
+import java.util.Set;
+
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
@@ -23,7 +25,7 @@ import de.charite.compbio.jannovar.reference.TranscriptProjectionDecorator;
 class VCFAnnotationData {
 
 	/** predicted effects */
-	public ImmutableSortedSet<VariantEffect> effects = ImmutableSortedSet.<VariantEffect> of();
+	public Set<VariantEffect> effects = ImmutableSortedSet.<VariantEffect> of();
 	/** predicted impact */
 	public PutativeImpact impact = null;
 	/** symbol of affected gene */
@@ -57,7 +59,7 @@ class VCFAnnotationData {
 	/** distance */
 	public int distance = -1;
 	/** additional messages for the annotation */
-	public ImmutableSortedSet<AnnotationMessage> messages = ImmutableSortedSet.<AnnotationMessage> of();
+	public Set<AnnotationMessage> messages = ImmutableSortedSet.<AnnotationMessage> of();
 
 	public void setAnnoLoc(AnnotationLocation annoLoc) {
 		if (annoLoc == null)

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotations.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/VariantAnnotations.java
@@ -95,7 +95,7 @@ public final class VariantAnnotations implements VariantDescription {
 		if (anno == null || anno.getEffects().isEmpty())
 			return VariantEffect.SEQUENCE_VARIANT;
 		else
-			return anno.getEffects().first();
+			return anno.getEffects().iterator().next();
 	}
 
 	@Override

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java
@@ -1,10 +1,8 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
-import java.util.ArrayList;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.EnumSet;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -48,6 +46,12 @@ import de.charite.compbio.jannovar.reference.TranscriptSequenceOntologyDecorator
  */
 abstract class AnnotationBuilder {
 
+	private static final ImmutableSet<VariantEffect> SPLICE_VARIANT_EFFECTS = ImmutableSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
+		VariantEffect.SPLICE_ACCEPTOR_VARIANT, VariantEffect.SPLICE_REGION_VARIANT);
+	private static final Set<VariantEffect> UPSTREAM_GENE_VARIANT = Sets.immutableEnumSet(EnumSet.of(VariantEffect.UPSTREAM_GENE_VARIANT));
+	private static final Set<VariantEffect> DOWNSTREAM_GENE_VARIANT = Sets.immutableEnumSet(EnumSet.of(VariantEffect.DOWNSTREAM_GENE_VARIANT));
+	private static final Set<VariantEffect> INTERGENIC_VARIANT = Sets.immutableEnumSet(EnumSet.of(VariantEffect.INTERGENIC_VARIANT));
+
 	/** configuration */
 	protected final AnnotationBuilderOptions options;
 
@@ -70,7 +74,7 @@ abstract class AnnotationBuilder {
 	/** locus of the change, length() == 1 in case of point changes */
 	protected NucleotideRange ntChangeRange;
 	/** warnings and messages occuring during annotation process */
-	protected SortedSet<AnnotationMessage> messages = new TreeSet<AnnotationMessage>();
+	protected Set<AnnotationMessage> messages = EnumSet.noneOf(AnnotationMessage.class);
 
 	/**
 	 * Initialize the helper object with the given <code>transcript</code> and <code>change</code>.
@@ -153,16 +157,16 @@ abstract class AnnotationBuilder {
 		// Project genome to CDS position.
 		GenomePosition pos = changeInterval.getGenomeBeginPos();
 
-		ArrayList<VariantEffect> varTypes = new ArrayList<VariantEffect>();
+		Set<VariantEffect> varTypes = EnumSet.noneOf(VariantEffect.class);
 		if (changeInterval.length() == 0) {
 			final GenomePosition lPos = pos.shifted(-1);
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.liesInSpliceDonorSite(pos) || so.liesInSpliceDonorSite(lPos))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.liesInSpliceAcceptorSite(lPos) || so.liesInSpliceAcceptorSite(pos))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.liesInSpliceRegion(pos))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			// Check for being in intron/exon.
 			if (so.liesInExon(lPos) && so.liesInExon(pos))
 				varTypes.add(VariantEffect.NON_CODING_TRANSCRIPT_EXON_VARIANT);
@@ -171,11 +175,11 @@ abstract class AnnotationBuilder {
 		} else {
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			// Check for being in intron/exon.
 			if (so.overlapsWithExon(changeInterval))
 				varTypes.add(VariantEffect.NON_CODING_TRANSCRIPT_EXON_VARIANT);
@@ -190,7 +194,7 @@ abstract class AnnotationBuilder {
 	protected Annotation buildIntronicAnnotation() {
 		GenomePosition pos = change.getGenomeInterval().getGenomeBeginPos();
 
-		ArrayList<VariantEffect> varTypes = new ArrayList<VariantEffect>();
+		Set<VariantEffect> varTypes = EnumSet.noneOf(VariantEffect.class);
 		if (transcript.isCoding()) // always include intronic as variant type
 			varTypes.add(VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT);
 		else
@@ -199,26 +203,25 @@ abstract class AnnotationBuilder {
 			final GenomePosition lPos = pos.shifted(-1);
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.liesInSpliceDonorSite(pos) || so.liesInSpliceDonorSite(lPos))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.liesInSpliceAcceptorSite(lPos) || so.liesInSpliceAcceptorSite(pos))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.liesInSpliceRegion(pos))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 		} else {
 			GenomeInterval changeInterval = change.getGenomeInterval();
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 		}
 		// intronic variants have no effect on the protein but splice variants lead to "probably no protein produced"
 		// annotation, as in Mutalyzer.
 		ProteinChange proteinChange = ProteinMiscChange.build(true, ProteinMiscChangeType.NO_CHANGE);
-		if (!Sets.intersection(ImmutableSet.copyOf(varTypes), ImmutableSet.of(VariantEffect.SPLICE_DONOR_VARIANT,
-				VariantEffect.SPLICE_ACCEPTOR_VARIANT, VariantEffect.SPLICE_REGION_VARIANT)).isEmpty())
+		if (!Sets.intersection(Sets.immutableEnumSet(varTypes), SPLICE_VARIANT_EFFECTS).isEmpty())
 			proteinChange = ProteinMiscChange.build(true, ProteinMiscChangeType.DIFFICULT_TO_PREDICT);
 		return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(),
 				proteinChange, messages);
@@ -230,16 +233,16 @@ abstract class AnnotationBuilder {
 	protected Annotation buildUTRAnnotation() {
 		GenomePosition pos = change.getGenomeInterval().getGenomeBeginPos();
 
-		ArrayList<VariantEffect> varTypes = new ArrayList<VariantEffect>();
+		Set<VariantEffect> varTypes = EnumSet.noneOf(VariantEffect.class);
 		if (change.getGenomeInterval().length() == 0) {
 			GenomePosition lPos = pos.shifted(-1);
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if ((so.liesInSpliceDonorSite(lPos) && so.liesInSpliceDonorSite(pos)))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if ((so.liesInSpliceAcceptorSite(lPos) && so.liesInSpliceAcceptorSite(pos)))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if ((so.liesInSpliceRegion(lPos) && so.liesInSpliceRegion(pos)))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			// Check for being in 5' or 3' UTR.
 			if (so.liesInFivePrimeUTR(lPos)) {
 				// Check if variant overlaps really with an UTR
@@ -268,11 +271,11 @@ abstract class AnnotationBuilder {
 			GenomeInterval changeInterval = change.getGenomeInterval();
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			// Check for being in 5' or 3' UTR.
 			if (so.overlapsWithFivePrimeUTR(changeInterval)) {
 				// Check if variant overlaps really with an UTR
@@ -310,28 +313,28 @@ abstract class AnnotationBuilder {
 			// Empty interval, is insertion.
 			GenomePosition lPos = pos.shifted(-1);
 			if (so.liesInUpstreamRegion(lPos))
-				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.UPSTREAM_GENE_VARIANT), null,
+				return new Annotation(transcript, change, UPSTREAM_GENE_VARIANT, null,
 						null, null, null, messages);
 			else
 				// so.liesInDownstreamRegion(pos))
-				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.DOWNSTREAM_GENE_VARIANT), null,
+				return new Annotation(transcript, change, DOWNSTREAM_GENE_VARIANT, null,
 						null, null, null, messages);
 		} else {
 			// Non-empty interval, at least one reference base changed/deleted.
 			GenomeInterval changeInterval = change.getGenomeInterval();
 			if (so.overlapsWithUpstreamRegion(changeInterval))
-				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.UPSTREAM_GENE_VARIANT), null,
+				return new Annotation(transcript, change, UPSTREAM_GENE_VARIANT, null,
 						null, null, null, messages);
 			else
 				// so.overlapsWithDownstreamRegion(changeInterval)
-				return new Annotation(transcript, change, ImmutableList.of(VariantEffect.DOWNSTREAM_GENE_VARIANT), null,
+				return new Annotation(transcript, change, DOWNSTREAM_GENE_VARIANT, null,
 						null, null, null, messages);
 		}
 	}
 
 	/** @return intergenic anotation */
 	protected Annotation buildIntergenicAnnotation() {
-		return new Annotation(transcript, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT), null, null, null,
+		return new Annotation(transcript, change, INTERGENIC_VARIANT, null, null, null,
 				null, messages);
 	}
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilderDispatcher.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilderDispatcher.java
@@ -1,9 +1,11 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
+import java.util.EnumSet;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableList;
 
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeVariant;
@@ -19,6 +21,7 @@ import de.charite.compbio.jannovar.reference.TranscriptModel;
 public final class AnnotationBuilderDispatcher {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationBuilderDispatcher.class);
+	private static final Set<VariantEffect> INTERGENIC_VARIANT = Sets.immutableEnumSet(EnumSet.of(VariantEffect.INTERGENIC_VARIANT));
 
 	/** transcript to build annotation for */
 	private final TranscriptModel transcript;
@@ -27,8 +30,7 @@ public final class AnnotationBuilderDispatcher {
 	/** configuration to use */
 	private final AnnotationBuilderOptions options;
 
-	public AnnotationBuilderDispatcher(TranscriptModel transcript, GenomeVariant change,
-			AnnotationBuilderOptions options) {
+	public AnnotationBuilderDispatcher(TranscriptModel transcript, GenomeVariant change, AnnotationBuilderOptions options) {
 		this.transcript = transcript;
 		this.change = change;
 		this.options = options;
@@ -42,22 +44,22 @@ public final class AnnotationBuilderDispatcher {
 	 */
 	public Annotation build() throws InvalidGenomeVariant {
 		if (transcript == null)
-			return new Annotation(null, change, ImmutableList.of(VariantEffect.INTERGENIC_VARIANT), null,
+			return new Annotation(null, change, INTERGENIC_VARIANT, null,
 					new GenomicNucleotideChangeBuilder(change).build(), null, null);
 
 		switch (change.getType()) {
 		case SNV:
-			LOGGER.debug("Annotating SNV {}", new Object[] { change });
+			LOGGER.debug("Annotating SNV {}", change);
 			return new SNVAnnotationBuilder(transcript, change, options).build();
 		case DELETION:
-			LOGGER.debug("Annotating deletion {}", new Object[] { change });
+			LOGGER.debug("Annotating deletion {}", change);
 			return new DeletionAnnotationBuilder(transcript, change, options).build();
 		case INSERTION:
-			LOGGER.debug("Annotating insertion {}", new Object[] { change });
+			LOGGER.debug("Annotating insertion {}", change);
 			return new InsertionAnnotationBuilder(transcript, change, options).build();
 		case BLOCK_SUBSTITUTION:
 		default:
-			LOGGER.debug("Annotating block substitution {}", new Object[] { change });
+			LOGGER.debug("Annotating block substitution {}", change);
 			return new BlockSubstitutionAnnotationBuilder(transcript, change, options).build();
 		}
 	}

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/BlockSubstitutionAnnotationBuilder.java
@@ -1,9 +1,11 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
-import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 
+import com.google.common.collect.Sets;
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeVariant;
 import de.charite.compbio.jannovar.annotation.VariantEffect;
@@ -37,6 +39,9 @@ import de.charite.compbio.jannovar.reference.TranscriptModel;
  * @author <a href="mailto:manuel.holtgrewe@charite.de">Manuel Holtgrewe</a>
  */
 public final class BlockSubstitutionAnnotationBuilder extends AnnotationBuilder {
+
+	private static final Set<VariantEffect> TRANSCRIPT_ABLATION = Sets.immutableEnumSet(EnumSet.of(VariantEffect.TRANSCRIPT_ABLATION));
+	private static final Set<VariantEffect> START_LOST = Sets.immutableEnumSet(EnumSet.of(VariantEffect.START_LOST));
 
 	/**
 	 * @param transcript
@@ -89,12 +94,12 @@ public final class BlockSubstitutionAnnotationBuilder extends AnnotationBuilder 
 	}
 
 	private Annotation buildFeatureAblationAnnotation() {
-		return new Annotation(transcript, change, ImmutableList.of(VariantEffect.TRANSCRIPT_ABLATION), locAnno,
+		return new Annotation(transcript, change, TRANSCRIPT_ABLATION, locAnno,
 				getGenomicNTChange(), getCDSNTChange(), null, messages);
 	}
 
 	private Annotation buildStartLossAnnotation() {
-		return new Annotation(transcript, change, ImmutableList.of(VariantEffect.START_LOST), locAnno,
+		return new Annotation(transcript, change, START_LOST, locAnno,
 				getGenomicNTChange(), getCDSNTChange(), ProteinMiscChange.build(true, ProteinMiscChangeType.NO_PROTEIN),
 				messages);
 	}
@@ -129,7 +134,7 @@ public final class BlockSubstitutionAnnotationBuilder extends AnnotationBuilder 
 		// Java.
 
 		// the variant types, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
-		ArrayList<VariantEffect> varTypes = new ArrayList<VariantEffect>();
+		Set<VariantEffect> varTypes = EnumSet.noneOf(VariantEffect.class);
 		// the amino acid change, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
 		AminoAcidChange aaChange;
 		// the predicted protein change, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
@@ -187,15 +192,15 @@ public final class BlockSubstitutionAnnotationBuilder extends AnnotationBuilder 
 			//
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			if (so.overlapsWithTranslationalStopSite(changeInterval))
 				varTypes.add(VariantEffect.STOP_LOST);
 			else if (change.getAlt().length() > change.getRef().length())
-				varTypes.addAll(ImmutableList.of(VariantEffect.INTERNAL_FEATURE_ELONGATION));
+				varTypes.add(VariantEffect.INTERNAL_FEATURE_ELONGATION);
 			else if (change.getAlt().length() < change.getRef().length())
 				varTypes.addAll(ImmutableList.of(VariantEffect.FEATURE_TRUNCATION, VariantEffect.COMPLEX_SUBSTITUTION));
 			else
@@ -264,11 +269,11 @@ public final class BlockSubstitutionAnnotationBuilder extends AnnotationBuilder 
 			//
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			// Check whether it overlaps with the stop site.
 			if (so.overlapsWithTranslationalStopSite(changeInterval))
 				varTypes.add(VariantEffect.STOP_LOST);

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
@@ -1,6 +1,7 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
-import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 
@@ -119,7 +120,7 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 		// Java.
 
 		// the variant type, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
-		ArrayList<VariantEffect> varTypes = new ArrayList<VariantEffect>();
+		Set<VariantEffect> varTypes = EnumSet.noneOf(VariantEffect.class);
 		// the amino acid change, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
 		AminoAcidChange aaChange;
 		// the predicted protein change, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
@@ -170,11 +171,11 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 			//
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			// Check whether the variant overlaps with the stop site.
 			if (so.overlapsWithTranslationalStopSite(changeInterval))
 				varTypes.add(VariantEffect.STOP_LOST);
@@ -219,11 +220,11 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 			//
 			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 			if (so.overlapsWithSpliceDonorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 			else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 			else if (so.overlapsWithSpliceRegion(changeInterval))
-				varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 			// Check whether the variant overlaps with the stop site.
 			if (so.overlapsWithTranslationalStopSite(changeInterval))
 				varTypes.add(VariantEffect.STOP_LOST);

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
@@ -1,6 +1,7 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
-import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Set;
 
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.InvalidGenomeVariant;
@@ -170,7 +171,7 @@ public final class InsertionAnnotationBuilder extends AnnotationBuilder {
 		// Java.
 
 		// the variant type, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
-		ArrayList<VariantEffect> varTypes = new ArrayList<VariantEffect>();
+		Set<VariantEffect> varTypes = EnumSet.noneOf(VariantEffect.class);
 		// the amino acid change, updated in handleFrameShiftCase() and handleNonFrameShiftCase()
 		AminoAcidChange aaChange;
 		// the predicted protein change, updated in handleFrameShiftCase() and handleNonFrameShiftCase()

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/SNVAnnotationBuilder.java
@@ -1,8 +1,7 @@
 package de.charite.compbio.jannovar.annotation.builders;
 
-import java.util.ArrayList;
-
-import com.google.common.collect.ImmutableList;
+import java.util.EnumSet;
+import java.util.Set;
 
 import de.charite.compbio.jannovar.annotation.Annotation;
 import de.charite.compbio.jannovar.annotation.AnnotationMessage;
@@ -108,9 +107,9 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 			transcriptCodon = seqDecorator.getCodonAt(txPos, cdsPos);
 		} catch (InvalidCodonException e) {
 			// Bail out in the case of invalid codon from sequence
-			return new Annotation(transcript, change, new ArrayList<VariantEffect>(), locAnno, getGenomicNTChange(),
+			return new Annotation(transcript, change, EnumSet.noneOf(VariantEffect.class), locAnno, getGenomicNTChange(),
 					getCDSNTChange(), ProteinMiscChange.build(true, ProteinMiscChangeType.DIFFICULT_TO_PREDICT),
-					ImmutableList.of(AnnotationMessage.ERROR_PROBLEM_DURING_ANNOTATION));
+				EnumSet.of(AnnotationMessage.ERROR_PROBLEM_DURING_ANNOTATION));
 		}
 		String wtCodon = transcriptCodon;
 		if (options.isOverrideTxSeqWithGenomeVariantRef())
@@ -133,7 +132,7 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 			proteinChange = ProteinMiscChange.build(true, ProteinMiscChangeType.NO_CHANGE);
 
 		// Compute variant type.
-		ArrayList<VariantEffect> varTypes = computeVariantTypes(wtAA, varAA);
+		Set<VariantEffect> varTypes = computeVariantTypes(wtAA, varAA);
 		GenomeInterval changeInterval = change.getGenomeInterval();
 		if (so.overlapsWithTranslationalStartSite(changeInterval)) {
 			varTypes.add(VariantEffect.START_LOST);
@@ -152,11 +151,11 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 		}
 		// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
 		if (so.overlapsWithSpliceDonorSite(changeInterval))
-			varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_DONOR_VARIANT));
+			varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
 		else if (so.overlapsWithSpliceAcceptorSite(changeInterval))
-			varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT));
+			varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
 		else if (so.overlapsWithSpliceRegion(changeInterval))
-			varTypes.addAll(ImmutableList.of(VariantEffect.SPLICE_REGION_VARIANT));
+			varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 
 		// Build the resulting Annotation.
 		return new Annotation(transcript, change, varTypes, locAnno, getGenomicNTChange(), getCDSNTChange(),
@@ -178,8 +177,8 @@ public final class SNVAnnotationBuilder extends AnnotationBuilder {
 	 *            variant amino acid
 	 * @return variant types described by single nucleotide change
 	 */
-	private ArrayList<VariantEffect> computeVariantTypes(String wtAA, String varAA) {
-		ArrayList<VariantEffect> result = new ArrayList<VariantEffect>();
+	private Set<VariantEffect> computeVariantTypes(String wtAA, String varAA) {
+		Set<VariantEffect> result = EnumSet.noneOf(VariantEffect.class);
 		if (wtAA.equals(varAA))
 			result.add(VariantEffect.SYNONYMOUS_VARIANT);
 		else if (wtAA.equals("*"))

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomeInterval.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomeInterval.java
@@ -119,6 +119,9 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 
 	/** convert into GenomeInterval of the given strand */
 	public GenomeInterval withStrand(Strand strand) {
+		if (this.strand == strand) {
+			return this;
+		}
 		return new GenomeInterval(this, strand);
 	}
 
@@ -179,8 +182,7 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 	public boolean isLeftOf(GenomePosition pos) {
 		if (chr != pos.getChr())
 			return false; // wrong chromosome
-		if (pos.getStrand() != strand)
-			pos = pos.withStrand(strand); // ensure that we are on the correct strand
+		pos = ensureSameStrand(pos);
 		return (pos.getPos() >= endPos);
 	}
 
@@ -192,8 +194,7 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 	public boolean isRightOf(GenomePosition pos) {
 		if (chr != pos.getChr())
 			return false; // wrong chromosome
-		if (pos.getStrand() != strand)
-			pos = pos.withStrand(strand); // ensure that we are on the correct strand
+		pos = ensureSameStrand(pos);
 		return (pos.getPos() < beginPos);
 	}
 
@@ -205,9 +206,12 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 	public boolean isLeftOfGap(GenomePosition pos) {
 		if (chr != pos.getChr())
 			return false; // wrong chromosome
-		if (pos.getStrand() != strand)
-			pos = pos.withStrand(strand); // ensure that we are on the correct strand
+		pos = ensureSameStrand(pos);
 		return (pos.getPos() >= endPos);
+	}
+
+	private GenomePosition ensureSameStrand(GenomePosition pos) {
+		return pos.withStrand(strand);
 	}
 
 	/**
@@ -218,8 +222,7 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 	public boolean isRightOfGap(GenomePosition pos) {
 		if (chr != pos.getChr())
 			return false; // wrong chromosome
-		if (pos.getStrand() != strand)
-			pos = pos.withStrand(strand); // ensure that we are on the correct strand
+		pos = ensureSameStrand(pos);
 		return (pos.getPos() <= beginPos);
 	}
 
@@ -231,8 +234,7 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 	public boolean contains(GenomePosition pos) {
 		if (chr != pos.getChr())
 			return false; // wrong chromosome
-		if (pos.getStrand() != strand)
-			pos = pos.withStrand(strand); // ensure that we are on the correct strand
+		pos = ensureSameStrand(pos);
 		return (pos.getPos() >= beginPos && pos.getPos() < endPos);
 	}
 
@@ -245,8 +247,7 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 		// TODO(holtgrem): Test this.
 		if (chr != other.chr)
 			return false; // wrong chromosome
-		if (other.strand != strand)
-			other = other.withStrand(strand); // ensure that we are on the correct strand
+		other = ensureSameStrand(other);
 		return (other.beginPos >= beginPos && other.endPos <= endPos);
 	}
 
@@ -275,8 +276,12 @@ public final class GenomeInterval implements Serializable, Comparable<GenomeInte
 		// TODO(holtgrem): add test for this
 		if (chr != other.chr)
 			return false;
-		other = other.withStrand(strand);
+		other = ensureSameStrand(other);
 		return (other.beginPos < endPos && beginPos < other.endPos);
+	}
+
+	private GenomeInterval ensureSameStrand(GenomeInterval other) {
+		return other.withStrand(strand);
 	}
 
 	/*

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomePosition.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomePosition.java
@@ -103,6 +103,9 @@ public final class GenomePosition implements Serializable, Comparable<GenomePosi
 
 	/** convert into GenomePosition of the given strand */
 	public GenomePosition withStrand(Strand strand) {
+		if (this.strand == strand) {
+			return this;
+		}
 		return new GenomePosition(this, strand);
 	}
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomeVariant.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomeVariant.java
@@ -138,27 +138,6 @@ public final class GenomeVariant implements VariantDescription {
 	}
 
 	/**
-	 * Construct object and enforce strand.
-	 */
-	public GenomeVariant(GenomeVariant other, Strand strand) {
-		if (strand == other.pos.getStrand()) {
-			this.ref = other.ref;
-			this.alt = other.alt;
-		} else {
-			this.ref = DNAUtils.reverseComplement(other.ref);
-			this.alt = DNAUtils.reverseComplement(other.alt);
-		}
-
-		// Get position as 0-based position.
-
-		if (strand == other.pos.getStrand()) {
-			this.pos = other.pos;
-		} else {
-			this.pos = other.pos.shifted(this.ref.length() - 1).withStrand(strand);
-		}
-	}
-
-	/**
 	 * @return numeric ID of chromosome this change is on
 	 */
 	@Override
@@ -170,6 +149,7 @@ public final class GenomeVariant implements VariantDescription {
 	 * @return interval of the genome change
 	 */
 	public GenomeInterval getGenomeInterval() {
+		// note - it is not worth caching this as an instance field as this leads to worse GC performance
 		if (isSymbolic())
 			return new GenomeInterval(pos, 1);
 
@@ -183,7 +163,13 @@ public final class GenomeVariant implements VariantDescription {
 		if (pos.getStrand() == strand) {
 			return this;
 		}
-		return new GenomeVariant(this, strand);
+
+		String oppositeRef = DNAUtils.reverseComplement(ref);
+		String oppositeAlt = DNAUtils.reverseComplement(alt);
+
+		// Get position as 0-based position.
+		GenomePosition oppositePos = pos.shifted(this.ref.length() - 1).withStrand(strand);
+		return new GenomeVariant(oppositePos, oppositeRef, oppositeAlt, strand);
 	}
 
 	/**

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomeVariant.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/GenomeVariant.java
@@ -180,6 +180,9 @@ public final class GenomeVariant implements VariantDescription {
 	 * @return the GenomeChange on the given strand
 	 */
 	public GenomeVariant withStrand(Strand strand) {
+		if (pos.getStrand() == strand) {
+			return this;
+		}
 		return new GenomeVariant(this, strand);
 	}
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptProjectionDecorator.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/TranscriptProjectionDecorator.java
@@ -278,10 +278,11 @@ public final class TranscriptProjectionDecorator {
 		int currEndPos = 0; // current end position of exon in transcript
 		int i = 0;
 		for (GenomeInterval region : transcript.getExonRegions()) {
-			if (pos.getPos() < currEndPos + region.length())
+			int regionLength = region.length();
+			if (pos.getPos() < currEndPos + regionLength)
 				return i;
 			++i;
-			currEndPos += region.length();
+			currEndPos += regionLength;
 		}
 
 		// if pos was a valid transcript position then we should not reach here

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/GenomeIntervalTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/GenomeIntervalTest.java
@@ -51,7 +51,7 @@ public class GenomeIntervalTest {
 	@Test
 	public void testConstructForwardToReverseOneBased() {
 		GenomeInterval fwdInterval = new GenomeInterval(refDict, Strand.FWD, 1, 1000, 1100, PositionType.ONE_BASED);
-		GenomeInterval revInterval = new GenomeInterval(fwdInterval, Strand.REV);
+		GenomeInterval revInterval = fwdInterval.withStrand(Strand.REV);
 
 		Assert.assertEquals(revInterval.getStrand(), Strand.REV);
 		Assert.assertEquals(revInterval.getChr(), 1);
@@ -73,7 +73,7 @@ public class GenomeIntervalTest {
 	@Test
 	public void testConstructForwardToForwardOneBased() {
 		GenomeInterval fwdInterval = new GenomeInterval(refDict, Strand.FWD, 1, 1000, 1100, PositionType.ONE_BASED);
-		GenomeInterval fwdInterval2 = new GenomeInterval(fwdInterval, Strand.FWD);
+		GenomeInterval fwdInterval2 = fwdInterval.withStrand(Strand.FWD);
 
 		Assert.assertEquals(fwdInterval2.getStrand(), Strand.FWD);
 		Assert.assertEquals(fwdInterval2.getChr(), 1);
@@ -85,7 +85,7 @@ public class GenomeIntervalTest {
 	@Test
 	public void testConstructReverseToForwardOneBased() {
 		GenomeInterval revInterval = new GenomeInterval(refDict, Strand.REV, 1, 1000, 1100, PositionType.ONE_BASED);
-		GenomeInterval fwdInterval = new GenomeInterval(revInterval, Strand.FWD);
+		GenomeInterval fwdInterval = revInterval.withStrand(Strand.FWD);
 
 		Assert.assertEquals(fwdInterval.getStrand(), Strand.FWD);
 		Assert.assertEquals(fwdInterval.getChr(), 1);
@@ -107,7 +107,7 @@ public class GenomeIntervalTest {
 	@Test
 	public void testConstructReverseToReverseOneBased() {
 		GenomeInterval revInterval = new GenomeInterval(refDict, Strand.REV, 1, 1000, 1100, PositionType.ONE_BASED);
-		GenomeInterval revInterval2 = new GenomeInterval(revInterval, Strand.REV);
+		GenomeInterval revInterval2 = revInterval.withStrand(Strand.REV);
 
 		Assert.assertEquals(revInterval2.getStrand(), Strand.REV);
 		Assert.assertEquals(revInterval2.getChr(), 1);
@@ -119,7 +119,7 @@ public class GenomeIntervalTest {
 	@Test
 	public void testConstructForwardToReverseZeroBased() {
 		GenomeInterval fwdInterval = new GenomeInterval(refDict, Strand.FWD, 1, 1000, 1100, PositionType.ZERO_BASED);
-		GenomeInterval revInterval = new GenomeInterval(fwdInterval, Strand.REV);
+		GenomeInterval revInterval = fwdInterval.withStrand(Strand.REV);
 
 		Assert.assertEquals(revInterval.getStrand(), Strand.REV);
 		Assert.assertEquals(revInterval.getChr(), 1);
@@ -141,7 +141,7 @@ public class GenomeIntervalTest {
 	@Test
 	public void testConstructReverseToForwardZeroBased() {
 		GenomeInterval revInterval = new GenomeInterval(refDict, Strand.REV, 1, 1000, 1100, PositionType.ZERO_BASED);
-		GenomeInterval fwdInterval = new GenomeInterval(revInterval, Strand.FWD);
+		GenomeInterval fwdInterval = revInterval.withStrand(Strand.FWD);
 
 		Assert.assertEquals(fwdInterval.getStrand(), Strand.FWD);
 		Assert.assertEquals(fwdInterval.getChr(), 1);

--- a/jannovar-stats/src/main/java/de/charite/compbio/jannovar/stats/facade/StatisticsCollector.java
+++ b/jannovar-stats/src/main/java/de/charite/compbio/jannovar/stats/facade/StatisticsCollector.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
@@ -142,7 +141,7 @@ public class StatisticsCollector {
 		if (alleleAnno.getHighestImpactAnnotation() == null
 				|| alleleAnno.getHighestImpactAnnotation().getEffects() == null)
 			return;
-		final SortedSet<VariantEffect> effects = alleleAnno.getHighestImpactAnnotation().getEffects();
+		final Set<VariantEffect> effects = alleleAnno.getHighestImpactAnnotation().getEffects();
 		final ImmutableSortedSet<VariantEffect> codingEffects = ImmutableSortedSet.of(
 				VariantEffect.FRAMESHIFT_ELONGATION, VariantEffect.FRAMESHIFT_TRUNCATION,
 				VariantEffect.FRAMESHIFT_VARIANT, VariantEffect.INTERNAL_FEATURE_ELONGATION,


### PR DESCRIPTION
I'd like to submit this as it performs the annotation about 10% faster in benchmarks on real genome data (POMP WGS sample from Exomiser). Not that Jannovar is excessively slow, but it's nice to have a bit more CPU and RAM to spare if possible. 

The two main optimisations are to the ```GenomeInterval/Position/Variant withStrand()``` method which  previously did no checks to see if the object was already on the requested strand. In these cases the original object is simple returned instead of a new copy being created.

Secondly, for every Annotation being created there was a copy of an ```ArrayList<VariantEffect>``` into an ```ImmutableSortedMap```. Given ```VariantEffect``` is a ```Enum``` it has a more efficient ```EnumSet``` data structure which can be used to replace these, although this does change the signature of ```Annotation.getEffects()``` from ```ImmutableSortedMap<VariantEffect>``` to ```Set<VariantEffect>```. Given this usage was only used internally within the ```annotation``` package I though it worth changing.

Commit logs:
Add check to GenomeInterval, GenomePosition and GenomeVariant withStrand() to prevent excessive object creation

Add local variable to prevent re-calculation of region.length() in TranscriptProjectionDecorator
Replace internal implementation of Annotation.effects and Annotation.messages with more efficient Sets.immutableEnumSet()
Replace internal ArrayList / ImmutableList<VariantEffect> uses in AnnotationBuilders with more efficient EnumSet<VariantEffect>
Change Annotation return type of getEffects() and getMessages() to generic Set
Change VCFAnnotationData and VariantAnnotations to cater for return type changes in Annotation