### PR TITLE
CVE-2018-11771 (apache-commons compress package)

### DIFF
--- a/jannovar-core/pom.xml
+++ b/jannovar-core/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.4.1</version>
+            <version>[1.18,)</version>
         </dependency>
         <!-- HGVS variant description -->
         <dependency>


### PR DESCRIPTION
To get rid of the security issue update the commons-compress to 1.18

When reading a specially crafted ZIP archive, the read method of Apache Commons Compress 1.7 to 1.17's ZipArchiveInputStream can fail to return the correct EOF indication after the end of the stream has been reached. When combined with a java.io.InputStreamReader this can lead to an infinite stream, which can be used to mount a denial of service attack against services that use Compress' zip package.