### PR TITLE
Adding end pos to TSV annotator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Jannovar Changelog
 
+## develop
+
 ### jannovar-core
 
+* Putative impact of splice_region_variant has changed from MODERATE to LOW (see issue #439)
 * Decreasing log verbosity in one location when building database.
 * Fixing CDS region import in `RefSeqParser`
 * Putative impact of `splice_region_variant has` changed from MODERATE to LOW (see issue #439)
@@ -9,6 +12,10 @@
 * Adding support for rn6 RefSeq transcripts.
   Adding `allowNonCodingNm` directive for data source INI file to disable check that RefSeq NM transcript has CDS.
 * Adding versions to ENST accessions for ENSEMBL.
+
+### jannovar-vardbs
+
+* Bugfix: TSVAnnotator did not use end given column.
 
 ## v0.28
 

--- a/jannovar-vardbs/src/main/java/de/charite/compbio/jannovar/vardbs/generic_tsv/GenericTSVVariantContextProvider.java
+++ b/jannovar-vardbs/src/main/java/de/charite/compbio/jannovar/vardbs/generic_tsv/GenericTSVVariantContextProvider.java
@@ -90,8 +90,10 @@ public class GenericTSVVariantContextProvider implements DatabaseVariantContextP
 			final int delta = options.isOneBasedPositions() ? 0 : 1;
 			final int startPos = Integer.parseInt(tokens[options.getBeginColumnIndex() - 1])
 				- delta;
+			final int endPos = Integer.parseInt(tokens[options.getEndColumnIndex() - 1])
+				- delta;
 			builder.start(startPos);
-			builder.stop(startPos);
+			builder.stop(endPos);
 
 			if (options.getRefAlleleColumnIndex() > 0 && options.getAltAlleleColumnIndex() > 0) {
 				builder.alleles(tokens[options.getRefAlleleColumnIndex() - 1],


### PR DESCRIPTION
TSV annotation doe's not use the endColumn index, even you can provide it in the command-line interfac. (start column was always used as end column). 
This is problematic when trying to annotate Deletions (like CADD indel scores). Here the end position must be the the last Ref position.

This was a simple two liners to add this!