### PR TITLE
correct ANN and SVANN header line `Number` entry to `UNBOUND`

### DIFF
--- a/jannovar-cli/src/test/resources/pedigree_vars.jv_ad.vcf
+++ b/jannovar-cli/src/test/resources/pedigree_vars.jv_ad.vcf
@@ -1,9 +1,9 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=OffExome,Description="Variant off-exome in all effect predictions">
-##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
 ##INFO=<ID=INHERITANCE,Number=.,Type=String,Description="Compatible inheritance modes (AD, AR, XD, XR, MT)">
 ##INFO=<ID=INHERITANCE_RECESSIVE_DETAIL,Number=.,Type=String,Description="Extra annotation for recessive inheritance sub type (AR_HOM_ALT, AR_COMP_HET, XR_HOM_ALT, XR_COMP_HET)">
-##INFO=<ID=SVANN,Number=1,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=SVANN,Number=.,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
 ##contig=<ID=1,length=249250621>
 ##contig=<ID=10,length=135534747>
 ##description=The gene DDX11L1 matches AUTOSOMAL_DOMINANT and AUTOSOMAL_RECESSIVE

--- a/jannovar-cli/src/test/resources/pedigree_vars.jv_ar.vcf
+++ b/jannovar-cli/src/test/resources/pedigree_vars.jv_ar.vcf
@@ -1,9 +1,9 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=OffExome,Description="Variant off-exome in all effect predictions">
-##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
 ##INFO=<ID=INHERITANCE,Number=.,Type=String,Description="Compatible inheritance modes (AD, AR, XD, XR, MT)">
 ##INFO=<ID=INHERITANCE_RECESSIVE_DETAIL,Number=.,Type=String,Description="Extra annotation for recessive inheritance sub type (AR_HOM_ALT, AR_COMP_HET, XR_HOM_ALT, XR_COMP_HET)">
-##INFO=<ID=SVANN,Number=1,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=SVANN,Number=.,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
 ##contig=<ID=1,length=249250621>
 ##contig=<ID=10,length=135534747>
 ##description=The gene DDX11L1 matches AUTOSOMAL_DOMINANT and AUTOSOMAL_RECESSIVE

--- a/jannovar-cli/src/test/resources/semicolons.jv.vcf
+++ b/jannovar-cli/src/test/resources/semicolons.jv.vcf
@@ -1,7 +1,7 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=OffExome,Description="Variant off-exome in all effect predictions">
-##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
-##INFO=<ID=SVANN,Number=1,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=SVANN,Number=.,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
 ##contig=<ID=NC_000001.10,length=249250621>
 ##jannovarCommand
 ##jannovarVersion

--- a/jannovar-cli/src/test/resources/small.jv.vcf
+++ b/jannovar-cli/src/test/resources/small.jv.vcf
@@ -1,7 +1,7 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=OffExome,Description="Variant off-exome in all effect predictions">
-##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
-##INFO=<ID=SVANN,Number=1,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+##INFO=<ID=SVANN,Number=.,Type=String,Description="Functional SV Annotation:'Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|ERRORS / WARNINGS / INFO'">
 ##contig=<ID=NC_000001.10,length=249250621>
 ##jannovarCommand
 ##jannovarVersion

--- a/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantContextWriterConstructionHelper.java
+++ b/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantContextWriterConstructionHelper.java
@@ -10,6 +10,7 @@ import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import htsjdk.variant.vcf.VCFHeaderLineCount;
 
 import java.io.File;
 import java.io.OutputStream;
@@ -123,10 +124,10 @@ public final class VariantContextWriterConstructionHelper {
 	 */
 	public static VCFHeader extendHeaderFields(VCFHeader header) {
 		// add INFO line for standardized ANN field
-		VCFInfoHeaderLine annLine = new VCFInfoHeaderLine("ANN", 1, VCFHeaderLineType.String,
+		VCFInfoHeaderLine annLine = new VCFInfoHeaderLine("ANN", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String,
 			Annotation.VCF_ANN_DESCRIPTION_STRING);
 		header.addMetaDataLine(annLine);
-		VCFInfoHeaderLine svAnnLine = new VCFInfoHeaderLine("SVANN", 1, VCFHeaderLineType.String,
+		VCFInfoHeaderLine svAnnLine = new VCFInfoHeaderLine("SVANN", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String,
 			SVAnnotation.VCF_SVANN_DESCRIPTION_STRING);
 		header.addMetaDataLine(svAnnLine);
 		return header;

--- a/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantEffectHeaderExtender.java
+++ b/jannovar-htsjdk/src/main/java/de/charite/compbio/jannovar/htsjdk/VariantEffectHeaderExtender.java
@@ -5,6 +5,7 @@ import htsjdk.variant.vcf.VCFFilterHeaderLine;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import htsjdk.variant.vcf.VCFHeaderLineCount;
 
 /**
  * Code for adding headers for variant effect to VCF files
@@ -23,7 +24,7 @@ public class VariantEffectHeaderExtender {
 	public void addHeaders(VCFHeader header) {
 		// add INFO line for standardized ANN field
 		header.addMetaDataLine(
-			new VCFInfoHeaderLine("ANN", 1, VCFHeaderLineType.String, Annotation.VCF_ANN_DESCRIPTION_STRING));
+			new VCFInfoHeaderLine("ANN", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, Annotation.VCF_ANN_DESCRIPTION_STRING));
 		// add FILTER line for standardized OffExome filter
 		header.addMetaDataLine(
 			new VCFFilterHeaderLine(FILTER_EFFECT_OFF_EXOME, "Variant off-exome in all effect predictions"));

--- a/manual/filter.rst
+++ b/manual/filter.rst
@@ -66,7 +66,7 @@ The following shows how to limit the variants to those having a missense functio
     $ bcftools view -i 'ANN ~ "missense"' small.vcf
     ##fileformat=VCFv4.2
     ##FILTER=<ID=PASS,Description="All filters passed">
-    ##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+    ##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
     ##INFO=<ID=INHERITANCE,Number=.,Type=String,Description="Mode of Inheritance">
     ##contig=<ID=1,length=249250621>
     ##jannovarCommand=annotate-v -d data/hg19_refseq.ser -i small.vcf -o small.jv.vcf

--- a/manual/inheritance.rst
+++ b/manual/inheritance.rst
@@ -60,7 +60,7 @@ Note that all variants lie within the same gene, as shown in the following, anno
 .. code-block:: text
 
     ##fileformat=VCFv4.2
-    ##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+    ##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
     ##INFO=<ID=INHERITANCE,Number=.,Type=String,Description="Mode of Inheritance">
     ##contig=<ID=1,length=249250621>
     ##jannovarCommand=annotate-vcf -d data/hg19_refseq.ser -i small.vcf -o small.jv.vcf
@@ -91,7 +91,7 @@ The molecular impact annotation ``ANN`` is suppressed for brevity.
         -o small.ar.vcf --pedigree-file ar.ped
     $ cat small.ar.vcf
     ##fileformat=VCFv4.2
-    ##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+    ##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
     ##INFO=<ID=INHERITANCE,Number=.,Type=String,Description="Mode of Inheritance">
     ##contig=<ID=1,length=249250621>
     ##jannovarCommand=annotate-vcf -d data/hg19_refseq.ser -i small.vcf -o small.ar.vcf --pedigree-file ar.ped
@@ -120,7 +120,7 @@ Annotating AD Variants
         -o small.ad.vcf --pedigree-file ad.ped
     $ cat small.ad.vcf
     ##fileformat=VCFv4.2
-    ##INFO=<ID=ANN,Number=1,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
+    ##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations:'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos / cDNA.length|CDS.pos / CDS.length|AA.pos / AA.length|Distance|ERRORS / WARNINGS / INFO'">
     ##INFO=<ID=INHERITANCE,Number=.,Type=String,Description="Mode of Inheritance">
     ##contig=<ID=1,length=249250621>
     ##jannovarCommand=annotate-vcf -d data/hg19_refseq.ser -i small.vcf -o small.ad.vcf --pedigree-file ad.ped


### PR DESCRIPTION
Set Number in ANN VCF header lines to '.', i.e. to `UNBOUND`, as multiple annotations may occur comma-separated per VCF entry. I ran into this in downstream parsing that got confused by the current `Number=1` in the header, which expects exactly one entry in the `ANN` field, but often finds more.

These are the only places I found, where header lines for the `ANN` field are defined -- but please double-check if I have missed anything. Also, I think I am loading the correct `htsjdk` classes, but I have not tested these changes. And I am assuming, that the `SVANN` `INFO` field can also possibly have multiple entries per `VCF` entry and thus requires the same change.