### PR TITLE
fixes url for grch38 gff and rna to one that is (hopefully) stable

### DIFF
--- a/jannovar-cli/src/main/resources/default_sources.ini
+++ b/jannovar-cli/src/main/resources/default_sources.ini
@@ -218,8 +218,8 @@ allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
 chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p12_top_level.gff3.gz
-rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GFF/ref_GRCh38.p12_top_level.gff3.gz
+rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/RNA/rna.fa.gz
 faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; HG38 from RefSeq (only curated data sets)
@@ -231,8 +231,8 @@ allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
 chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p12_top_level.gff3.gz
-rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GFF/ref_GRCh38.p12_top_level.gff3.gz
+rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/RNA/rna.fa.gz
 faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; ---------------------------------------------------------------------------


### PR DESCRIPTION
NCBI's data at https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ are updated to p13, but the current version of default_sources.ini still refers (in the filename) to the p12 version.

Unfortunately, I'm not sure (with an admittedly brief look around the NCBI site) if there is a stable reference to the p13 data yet, but this pull request at least refers to a (hopefully-- if they don't move it) stable reference to the p12 version.