### PR TITLE
Update htsjdk to 2.20.3 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Jannovar Changelog
 
-## HEAD (unreleased)
+## develop
+
+### jannovar-htsjdk
+
+* Bumping HTSJDK dependency to v2.20.3 because 2.20.0 has a bug in the VariantContextBuilder
 
 ## v0.33
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>Jannovar</name>
 
     <properties>
-        <htsjdk.version>2.20.0</htsjdk.version>
+        <htsjdk.version>2.20.3</htsjdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <log4j.version>2.11.2</log4j.version>
 


### PR DESCRIPTION
because 2.20.0 has a bug in the VariantContextBuilder. See [htsjdk release](https://github.com/samtools/htsjdk/releases/tag/2.20.1)