### PR TITLE
fix (workaround) for broken download sources and faMT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### jannovar-core
 
-* Change hard-coded chrMT renaming into a new one where it can use multiple genomes from multiple species. Still need improvement
+* Remove hard-coded chrMT renaming. Filenames for download that have a ? in their URL will be splitted and only the first part before the ? is used a file name in the download path.
+* Making faMT annotation for refSeq optional
 * Update RefSeq parser that does not run into null-pointer exceptions on mouse and rat genome (e.g. when no exon defines the gene name)
 
 ## v0.33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Jannovar Changelog
 
-## HEAD (unreleased)
+## development
+
+### jannovar-cli
+
+* disabeling ensemble for mouse (does not work with an hgnc file)
+* updating broken links in download source file
+* Adding faMT genomes for all refseq annotations
+
+### jannovar-core
+
+* Change hard-coded chrMT renaming into a new one where it can use multiple genomes from multiple species. Still need improvement
+* Update RefSeq parser that does not run into null-pointer exceptions on mouse and rat genome (e.g. when no exon defines the gene name)
 
 ## v0.33
 

--- a/jannovar-cli/src/main/resources/default_sources.ini
+++ b/jannovar-cli/src/main/resources/default_sources.ini
@@ -73,6 +73,9 @@ chrToAccessions.format=chr_NC_gi
 chrToAccessions.matchLast=HuRef
 gtf=https://ftp.ensembl.org/pub/release-54/gtf/homo_sapiens/Homo_sapiens.NCBI36.54.gtf.gz
 cdna=https://ftp.ensembl.org/pub/release-54/fasta/homo_sapiens/cdna/Homo_sapiens.NCBI36.54.cdna.all.fa.gz
+table_gene_main=https://ftp.ensembl.org/pub/release-54/mysql/ensembl_mart_54/hsapiens_gene_ensembl__gene__main.txt.gz
+table_hgnc=https://ftp.ensembl.org/pub/release-54/mysql/ensembl_mart_54/hsapiens_gene_ensembl__ox_HGNC__dm.txt.gz
+table_entrezgene=https://ftp.ensembl.org/pub/release-54/mysql/ensembl_mart_54/hsapiens_gene_ensembl__ox_EntrezGene__dm.txt.gz
 
 ; HG18 from RefSeq
 [hg18/refseq]
@@ -85,6 +88,7 @@ chrToAccessions.format=chr_NC_gi
 chrToAccessions.matchLast=HuRef
 gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/BUILD.36.3/GFF/ref_NCBI36_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/BUILD.36.3/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; HG18 from RefSeq (only curated data sets)
 [hg18/refseq_curated]
@@ -98,6 +102,7 @@ chrToAccessions.format=chr_NC_gi
 chrToAccessions.matchLast=HuRef
 gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/BUILD.36.3/GFF/ref_NCBI36_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/BUILD.36.3/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; ---------------------------------------------------------------------------
 ; hg19/GRCh37
@@ -162,8 +167,8 @@ allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/chromInfo.txt.gz
 chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/Assembled_chromosomes/chr_accessions_GRCh37.p13
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
-rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
+rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
 faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; HG19 from RefSeq interim alignment, only curated (see https://www.ncbi.nlm.nih.gov/books/NBK430989/#_news_02-14-2017-interim-annotation-update-human_)
@@ -175,8 +180,8 @@ allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/chromInfo.txt.gz
 chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.105/Assembled_chromosomes/chr_accessions_GRCh37.p13
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
-rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GRCh37.p13_interim_annotation/interim_GRCh37.p13_top_level_2017-01-13.gff3.gz
+rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GRCh37.p13_interim_annotation/interim_GRCh37.p13_rna.fa.gz
 faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; ---------------------------------------------------------------------------
@@ -188,7 +193,7 @@ faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report
 type=ucsc
 alias=MT,M,chrM
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
+chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
 knownCanonical=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/knownCanonical.txt.gz
 knownGene=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz
@@ -202,7 +207,7 @@ faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report
 type=ensembl
 alias=MT,M,chrM
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
+chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
 gtf=https://ftp.ensembl.org/pub/release-91/gtf/homo_sapiens/Homo_sapiens.GRCh38.91.gtf.gz
 cdna=https://ftp.ensembl.org/pub/release-91/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh38.cdna.all.fa.gz
@@ -216,10 +221,10 @@ type=refseq
 alias=MT,M,chrM
 allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
+chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p12_top_level.gff3.gz
-rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GFF/ref_GRCh38.p12_top_level.gff3.gz
+rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/RNA/rna.fa.gz
 faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; HG38 from RefSeq (only curated data sets)
@@ -229,10 +234,10 @@ alias=MT,M,chrM
 onlyCurated=true
 allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/Assembled_chromosomes/chr_accessions_GRCh38.p12
+chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/Assembled_chromosomes/chr_accessions_GRCh38.p12
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/GFF/ref_GRCh38.p12_top_level.gff3.gz
-rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/RNA/rna.fa.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/GFF/ref_GRCh38.p12_top_level.gff3.gz
+rna=https://ftp.ncbi.nlm.nih.gov/genomes/H_sapiens/ARCHIVE/ANNOTATION_RELEASE.109/RNA/rna.fa.gz
 faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=251831106
 
 ; ---------------------------------------------------------------------------
@@ -253,14 +258,18 @@ kgXref=http://hgdownload.soe.ucsc.edu/goldenPath/mm9/database/kgXref.txt.gz
 knownToLocusLink=http://hgdownload.soe.ucsc.edu/goldenPath/mm9/database/knownToLocusLink.txt.gz
 
 ; MM9 from Ensembl
-[mm9/ensembl]
-type=ensembl
-alias=MT,M,chrM
-chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/mm9/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37.2/Assembled_chromosomes/chr_accessions_MGSCv37
-chrToAccessions.format=chr_accessions
-gtf=https://ftp.ensembl.org/pub/release-67/gtf/mus_musculus/Mus_musculus.NCBIM37.67.gtf.gz
-cdna=https://ftp.ensembl.org/pub/release-67/fasta/mus_musculus/cdna/Mus_musculus.NCBIM37.67.cdna.all.fa.gz
+; BOKEN because HGNC file is only available on humans
+; [mm9/ensembl]
+; type=ensembl
+; alias=MT,M,chrM
+; chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/mm9/database/chromInfo.txt.gz
+; chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37.2/Assembled_chromosomes/chr_accessions_MGSCv37
+; chrToAccessions.format=chr_accessions
+; gtf=https://ftp.ensembl.org/pub/release-67/gtf/mus_musculus/Mus_musculus.NCBIM37.67.gtf.gz
+; cdna=https://ftp.ensembl.org/pub/release-67/fasta/mus_musculus/cdna/Mus_musculus.NCBIM37.67.cdna.all.fa.gz
+; table_gene_main=https://ftp.ensembl.org/pub/release-67/mysql/ensembl_mart_67/mmusculus_gene_ensembl__gene__main.txt.gz
+; table_hgnc=
+; table_entrezgene=https://ftp.ensembl.org/pub/release-67/mysql/ensembl_mart_67/mmusculus_gene_ensembl__ox_entrezgene__dm.txt.gz
 
 ; MM9 from RefSeq
 [mm9/refseq]
@@ -272,6 +281,7 @@ chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37
 chrToAccessions.format=chr_accessions
 gff=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37.2/GFF/ref_MGSCv37_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37.2/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=34538597
 
 ; MM9 from RefSeq (only curated data sets)
 [mm9/refseq_curated]
@@ -284,6 +294,7 @@ chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37
 chrToAccessions.format=chr_accessions
 gff=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37.2/GFF/ref_MGSCv37_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37.2/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=34538597
 
 ; ---------------------------------------------------------------------------
 ; mm10
@@ -294,7 +305,7 @@ rna=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/ARCHIVE/BUILD.37.2/RNA/rna.f
 type=ucsc
 alias=MT,M,chrM
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p4
+chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p6
 chrToAccessions.format=chr_accessions
 knownCanonical=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/knownCanonical.txt.gz
 knownGene=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz
@@ -303,14 +314,18 @@ kgXref=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/kgXref.txt.gz
 knownToLocusLink=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/knownToLocusLink.txt.gz
 
 ; MM10 from Ensembl
-[mm10/ensembl]
-type=ensembl
-alias=MT,M,chrM
-chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p4
-chrToAccessions.format=chr_accessions
-gtf=https://ftp.ensembl.org/pub/release-74/gtf/mus_musculus/Mus_musculus.GRCm38.74.gtf.gz
-cdna=https://ftp.ensembl.org/pub/release-74/fasta/mus_musculus/cdna/Mus_musculus.GRCm38.74.cdna.all.fa.gz
+; BOKEN because HGNC file is only available on humans
+; [mm10/ensembl]
+; type=ensembl
+; alias=MT,M,chrM
+; chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/chromInfo.txt.gz
+; chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p6
+; chrToAccessions.format=chr_accessions
+; gtf=https://ftp.ensembl.org/pub/release-74/gtf/mus_musculus/Mus_musculus.GRCm38.74.gtf.gz
+; cdna=https://ftp.ensembl.org/pub/release-74/fasta/mus_musculus/cdna/Mus_musculus.GRCm38.74.cdna.all.fa.gz
+; table_gene_main=https://ftp.ensembl.org/pub/release-74/mysql/ensembl_mart_74/mmusculus_gene_ensembl__gene__main.txt.gz
+; table_hgnc=
+; table_entrezgene=https://ftp.ensembl.org/pub/release-74/mysql/ensembl_mart_74/mmusculus_gene_ensembl__ox_entrezgene__dm.txt.gz
 
 ; MM10 from RefSeq
 [mm10/refseq]
@@ -318,10 +333,11 @@ type=refseq
 alias=MT,M,chrM
 allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p4
+chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p6
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/GFF/ref_GRCm38.p4_top_level.gff3.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/GFF/ref_GRCm38.p6_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=34538597
 
 ; MM10 from RefSeq (only curated data sets)
 [mm10/refseq_curated]
@@ -330,10 +346,11 @@ alias=MT,M,chrM
 onlyCurated=true
 allowNonCodingNm=true
 chromInfo=http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/chromInfo.txt.gz
-chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p4
+chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/Mus_musculus/Assembled_chromosomes/chr_accessions_GRCm38.p6
 chrToAccessions.format=chr_accessions
-gff=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/GFF/ref_GRCm38.p4_top_level.gff3.gz
+gff=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/GFF/ref_GRCm38.p6_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/M_musculus/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=34538597
 
 ; ---------------------------------------------------------------------------
 ; rn6
@@ -348,6 +365,7 @@ chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/R_norvegicus/ARCHIVE/ANNOTA
 chrToAccessions.format=chr_accessions
 gff=https://ftp.ncbi.nlm.nih.gov/genomes/R_norvegicus/ARCHIVE/ANNOTATION_RELEASE.105/GFF/ref_Rnor_6.0_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/R_norvegicus/ARCHIVE/ANNOTATION_RELEASE.105/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=110189714
 
 [rn6/refseq_curated]
 type=refseq
@@ -359,3 +377,4 @@ chrToAccessions=https://ftp.ncbi.nlm.nih.gov/genomes/R_norvegicus/ARCHIVE/ANNOTA
 chrToAccessions.format=chr_accessions
 gff=https://ftp.ncbi.nlm.nih.gov/genomes/R_norvegicus/ARCHIVE/ANNOTATION_RELEASE.105/GFF/ref_Rnor_6.0_top_level.gff3.gz
 rna=https://ftp.ncbi.nlm.nih.gov/genomes/R_norvegicus/ARCHIVE/ANNOTATION_RELEASE.105/RNA/rna.fa.gz
+faMT=https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?save=file&db=nuccore&report=fasta&id=110189714

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/DataSource.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/DataSource.java
@@ -76,6 +76,13 @@ public abstract class DataSource {
 	 * @return list of keys that are required to have a URL for download in {@link #iniSection}
 	 */
 	protected abstract ImmutableList<String> getURLKeys();
+	
+	/**
+	 * @return list of keys that are optional to have a URL for download in {@link #iniSection}
+	 */
+	protected ImmutableList<String> getOptionalURLKeys() {
+		return ImmutableList.of();
+	}
 
 	/**
 	 * @return list of URLs with files to download for this data source
@@ -84,6 +91,11 @@ public abstract class DataSource {
 		ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>();
 		for (String key : getURLKeys())
 			builder.add(iniSection.fetch(key));
+		for (String key : getOptionalURLKeys())
+			if (iniSection.containsKey(key)) {
+				builder.add(iniSection.fetch(key));
+			}
+			
 		// Always download hgnc_complete_set.txt
 		builder.add(HGNCParser.DOWNLOAD_URL);
 		return builder.build();

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/JannovarDataFactory.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/JannovarDataFactory.java
@@ -78,7 +78,7 @@ public abstract class JannovarDataFactory {
 				LOGGER.info("Downloading {}", url);
 				URL src = new URL(url);
 				final String fileName;
-				if (url.contains("251831106")) {
+				if (url.contains("viewer.cgi?save=file&db=nuccore&report=fasta&id=")) {
 					fileName = "chrMT.fasta";
 				} else {
 					fileName = new File(src.getPath()).getName();

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/JannovarDataFactory.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/JannovarDataFactory.java
@@ -77,12 +77,8 @@ public abstract class JannovarDataFactory {
 			for (String url : dataSource.getDownloadURLs()) {
 				LOGGER.info("Downloading {}", url);
 				URL src = new URL(url);
-				final String fileName;
-				if (url.contains("viewer.cgi?save=file&db=nuccore&report=fasta&id=")) {
-					fileName = "chrMT.fasta";
-				} else {
-					fileName = new File(src.getPath()).getName();
-				}
+				final String fileName = new File(src.getPath()).getName();
+				
 				File dest = new File(PathUtil.join(targetDir, fileName));
 				downloader.copyURLToFile(src, dest);
 

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/RefSeqDataSource.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/datasource/RefSeqDataSource.java
@@ -13,7 +13,11 @@ final class RefSeqDataSource extends DataSource {
 	/**
 	 * expected keys in data source configuration file
 	 */
-	private final ImmutableList<String> urlKeys = ImmutableList.of("gff", "rna", "chromInfo", "chrToAccessions", "faMT");
+	private final ImmutableList<String> urlKeys = ImmutableList.of("gff", "rna", "chromInfo", "chrToAccessions");
+	/**
+	 * optional keys in data source configuration file
+	 */
+	private final ImmutableList<String> optionalUrlKeys = ImmutableList.of("faMT");
 
 	RefSeqDataSource(DatasourceOptions options, Section iniSection) throws InvalidDataSourceException {
 		super(options, iniSection);
@@ -29,6 +33,10 @@ final class RefSeqDataSource extends DataSource {
 	@Override
 	protected ImmutableList<String> getURLKeys() {
 		return urlKeys;
+	}
+	@Override
+	protected ImmutableList<String> getOptionalURLKeys() {
+		return optionalUrlKeys;
 	}
 
 }

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/impl/parse/refseq/RefSeqParser.java
@@ -118,7 +118,8 @@ public class RefSeqParser implements TranscriptParser {
 
 		// Load the FASTA file and assign to the builders.
 		final String pathFASTA = PathUtil.join(basePath, getINIFileName("rna"));
-		loadMitochondrialFASTA(builders, PathUtil.join(basePath, "chrMT.fasta"));
+		loadMitochondrialFASTA(builders);
+		
 		loadFASTA(builders, pathFASTA);
 
 		// Create final list of TranscriptModels.
@@ -144,19 +145,26 @@ public class RefSeqParser implements TranscriptParser {
 	 * Load chrMT sequence (if available) and assign into chrMT builders.
 	 *
 	 * @param builders The transcript builders to update.
-	 * @param pathFasta The path to the chrMT.fasta file.
+	 * @param pathFasta The path to the fasta file.
 	 *
 	 * @throws TranscriptParseException on problems with parsing the FASTA.
 	 */
-	private void loadMitochondrialFASTA(Map<String, TranscriptModelBuilder> builders, String pathFasta)
+	private void loadMitochondrialFASTA(Map<String, TranscriptModelBuilder> builders)
 		throws TranscriptParseException {
 		if (!refDict.getContigNameToID().containsKey("chrMT")) {
 			LOGGER.info("The genome does not have a chrMT, skipping.");
 			return;
-		} else if (!new File(pathFasta).exists()) {
+		} else if (!iniSection.containsKey("faMT")) {
+			LOGGER.warn("Key for chrMT FASTA File does not exist, skipping.");
+			return;
+		}
+		
+		final String pathFasta = PathUtil.join(basePath, getINIFileName("faMT"));
+		if (!new File(pathFasta).exists()) {
 			LOGGER.warn("The chrMT FASTA File {} does not exist, skipping.", new Object[]{ pathFasta });
 			return;
 		}
+		
 
 		final int idMT = refDict.getContigNameToID().get("chrMT");
 
@@ -199,7 +207,11 @@ public class RefSeqParser implements TranscriptParser {
 	 * @return file name from INI <code>key</code.
 	 */
 	private String getINIFileName(String key) {
-		return new File(iniSection.get(key)).getName();
+		String name = new File(iniSection.get(key)).getName();
+		if (name.contains("?")) {
+			name = name.split("\\?")[0];
+		}
+		return name;
 	}
 
 	/**


### PR DESCRIPTION
### jannovar-cli

* disabling ensemble for mouse (does not work with an hgnc file)
* updating broken links in download source file
* Adding faMT genomes for all refseq annotations

### jannovar-core

* Change hard-coded chrMT renaming into a new one where it can use multiple genomes from multiple species. Still need improvement
* Update RefSeq parser that does not run into null-pointer exceptions on mouse and rat genome (e.g. when no exon defines the gene name)