### PR TITLE
Update Genotype internals to pre-calculate values

### DIFF
--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/mendel/Genotype.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/mendel/Genotype.java
@@ -3,9 +3,8 @@ package de.charite.compbio.jannovar.mendel;
 import com.google.common.collect.ImmutableList;
 import de.charite.compbio.jannovar.Immutable;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Representation of a genotype in an individual
@@ -14,7 +13,7 @@ import java.util.stream.Collectors;
  * reference allele is represented by the integer <code>0</code>. <code>-1</code> encodes no-call.
  * <p>
  * Jannovar will define the zygosity in a very soft way. We do not want to throw too much things away. If all
- * {@link Genotype} are no-calls then teh gebnotype is not observed. But if we have one {@link Genotype} called and
+ * {@link Genotype} are no-calls then the genotype is not observed. But if we have one {@link Genotype} called and
  * another is a no-call (e.g 0/.) we will consider fo the no-call all possibilities. So it can be het or homRef. This
  * behaviour is different to HTSJDK VariantContexed where they have a additional mixed class for such genotypes.
  *
@@ -29,9 +28,15 @@ public class Genotype {
 	public static final int REF_CALL = 0;
 
 	/**
-	 * List of allele numbers
+	 * List of allele numbers/calls
 	 */
-	private final ImmutableList<Integer> alleleNumbers;
+	private final int[] alleleNumbers;
+	private final int ploidy;
+	private final boolean hasNoObservedCalls;
+
+	private final boolean isHet;
+	private final boolean isHomRef;
+	private final boolean isHomAlt;
 
 	/**
 	 * Construct {@link Genotype} with list of allele numbers
@@ -39,47 +44,129 @@ public class Genotype {
 	 * @param alleleNumbers The allele numbers to initialize with
 	 */
 	public Genotype(Collection<Integer> alleleNumbers) {
-		this.alleleNumbers = ImmutableList.copyOf(alleleNumbers);
+		// one-time unboxing
+		this.alleleNumbers = alleleNumbers.stream().mapToInt(i -> i).toArray();
+		// now we're in a world of primitives
+		this.ploidy = this.alleleNumbers.length;
+		// These values are pre-calculated and cached as they are called many times during the
+		// inheritance mode analysis which leads to huge GC and autoboxing overhead when
+		// calculating them using the streams API. Doing so leads to very long hangs of several
+		// minutes when using the MendelianInheritanceChecker on 20K variants where ~40% of CPU was
+		// spent on calling isNotObserved().
+		int[] observedCalls = findObservedCalls(ploidy, this.alleleNumbers);
+		this.hasNoObservedCalls = observedCalls.length == 0;
+		this.isHet = calculateIsHet(ploidy, hasNoObservedCalls, this.alleleNumbers);
+		this.isHomRef = calculateIsHomRef(hasNoObservedCalls, this.alleleNumbers);
+		this.isHomAlt = calculateIsHomAlt(hasNoObservedCalls, observedCalls);
+	}
+
+	private int[] findObservedCalls(int numCalls, int[] alleleNumbers) {
+		int numObservedCalls = 0;
+		int[] temp = new int[numCalls];
+		for (int i = 0; i < numCalls ; i++) {
+			int call = alleleNumbers[i];
+			if (call != NO_CALL) {
+				temp[numObservedCalls++] = call;
+			}
+		}
+
+		if (numObservedCalls == numCalls) {
+			// all calls were observed, return original array
+			return alleleNumbers;
+		}
+		// return shortened array containing only observed calls
+		int[] observedCalls = new int[numObservedCalls];
+		System.arraycopy(temp, 0, observedCalls, 0, numObservedCalls);
+		return observedCalls;
+	}
+
+	/**
+	 * @return <code>true</code> if the sample is heterozygous. One call can be no_call, <code>false</code> otherwise
+	 */
+	private boolean calculateIsHet(int ploidy, boolean hasNoObservedCalls, int[] alleleNumbers) {
+		if (ploidy != 2 || hasNoObservedCalls) {
+			// only diploid genotypes can be heterozygous
+			// we want to have at least one observed call
+			return false;
+		}
+		return !(alleleNumbers[0] == alleleNumbers[1]);
+	}
+
+	/**
+	 * @return <code>true</code> if the sample is homozygous ref. Can have exactly one {@value #NO_CALL},
+	 * <code>false</code> otherwise
+	 */
+	private boolean calculateIsHomRef(boolean hasNoObservedCalls, int[] alleleNumbers) {
+		// we want to have at least one observed call
+		if (hasNoObservedCalls) {
+			return false;
+		}
+		// all alleles must be REF
+		for (int x : alleleNumbers) {
+			if (x != REF_CALL && x != NO_CALL) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean calculateIsHomAlt(boolean hasNoObservedCalls, int[] observedCalls) {
+		// we want to have at least one observed call
+		// hom alt cannot have a ref call
+		if (hasNoObservedCalls || hasRefCall(observedCalls)) {
+			return false;
+		}
+		int alt = observedCalls[0];
+		for (int i = 1; i < observedCalls.length ; i++) {
+			if (alt != observedCalls[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean hasRefCall(int[] observedCalls) {
+		for (int x : observedCalls) {
+			if (x == REF_CALL) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
 	 * @return {@link ImmutableList} of alleles in this genotype
 	 */
 	public ImmutableList<Integer> getAlleleNumbers() {
-		return alleleNumbers;
+		return Arrays.stream(alleleNumbers).boxed().collect(ImmutableList.toImmutableList());
 	}
 
 	/**
 	 * @return Number of alleles in the genotype
 	 */
 	public int getPloidy() {
-		return alleleNumbers.size();
+		return ploidy;
 	}
 
 	/**
 	 * @return <code>true</code> if the sample is diploid, <code>false</code> otherwise
 	 */
 	public boolean isDiploid() {
-		return (getPloidy() == 2);
+		return ploidy == 2;
 	}
 
 	/**
 	 * @return <code>true</code> if the sample is monoploid, <code>false</code> otherwise
 	 */
 	public boolean isMonoploid() {
-		return (getPloidy() == 1);
+		return ploidy == 1;
 	}
 
 	/**
 	 * @return <code>true</code> if the sample is heterozygous. One call can be no_call, <code>false</code> otherwise
 	 */
 	public boolean isHet() {
-		if (!isDiploid())
-			return false; // only diploid genotypes cann be heterozygous
-		if (isNotObserved())
-			return false; // we want to have at least one observed call
-		return !alleleNumbers.get(0).equals(alleleNumbers.get(1));
-
+		return isHet;
 	}
 
 	/**
@@ -87,70 +174,55 @@ public class Genotype {
 	 * <code>false</code> otherwise
 	 */
 	public boolean isHomRef() {
-		if (alleleNumbers.isEmpty())
-			return false; // empty calls are nothing
-		if (isNotObserved())
-			return false; // we want to have at least one observed call
-		return alleleNumbers.stream().allMatch(x -> x == REF_CALL || x == NO_CALL);
+		return isHomRef;
 	}
 
 	/**
 	 * @return <code>true</code> if the sample is homozygous alt, <code>false</code> otherwise
 	 */
 	public boolean isHomAlt() {
-		if (alleleNumbers.isEmpty())
-			return false; // empty calls are nothing
-		if (isNotObserved())
-			return false; // we want to have at least one observed call
-
-		boolean noRefCall = alleleNumbers.stream().noneMatch(x -> x == REF_CALL);
-		if (!noRefCall)
-			return false;
-
-		List<Integer> calledAlts = alleleNumbers.stream().filter(n -> n != NO_CALL).collect(Collectors.toList());
-		Integer alt = calledAlts.get(0);
-		for (Integer otherAlt : calledAlts) {
-			if (!alt.equals(otherAlt))
-				return false;
-		}
-		return true;
+		return isHomAlt;
 	}
 
 	/**
 	 * @return <code>true</code> if the genotype is not observed in all alleles
 	 */
 	public boolean isNotObserved() {
-		return alleleNumbers.stream().allMatch(n -> n == NO_CALL);
+		return hasNoObservedCalls;
 	}
 
 	@Override
 	public String toString() {
-		return "Genotype [alleleNumbers=" + alleleNumbers + "]";
+		String alleleNumbersString = makeAlleleNumbersString();
+		return "Genotype [alleleNumbers=" + alleleNumbersString + "]";
+	}
+
+	private String makeAlleleNumbersString() {
+		if (ploidy == 0) {
+			return "[]";
+		}
+		StringBuilder sb = new StringBuilder();
+		sb.append('[');
+		for (int i = 0; i < ploidy; i++) {
+			sb.append(alleleNumbers[i]);
+			if (i == ploidy - 1) {
+				break;
+			}
+			sb.append(',').append(' ');
+		}
+		return sb.append(']').toString();
 	}
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((alleleNumbers == null) ? 0 : alleleNumbers.hashCode());
-		return result;
+		return Arrays.hashCode(alleleNumbers);
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Genotype other = (Genotype) obj;
-		if (alleleNumbers == null) {
-			if (other.alleleNumbers != null)
-				return false;
-		} else if (!alleleNumbers.equals(other.alleleNumbers))
-			return false;
-		return true;
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof Genotype)) return false;
+		Genotype genotype = (Genotype) o;
+		return Arrays.equals(alleleNumbers, genotype.alleleNumbers);
 	}
-
 }

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/GenotypeTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/mendel/GenotypeTest.java
@@ -215,8 +215,14 @@ public class GenotypeTest {
 		Genotype two = new Genotype(Arrays.asList(1, 2));
 		Genotype three = new Genotype(Arrays.asList(1, 1));
 		Genotype four = new Genotype(Collections.singletonList(1));
-		assertTrue(one.equals(two));
-		assertFalse(one.equals(three));
-		assertFalse(one.equals(four));
+		assertEquals(one, two);
+		assertNotEquals(one, three);
+		assertNotEquals(one, four);
+	}
+
+	@Test
+	public void testToString() {
+		System.out.println(new Genotype(Arrays.asList(1, 2)));
+		System.out.println(new Genotype(Collections.emptyList()));
 	}
 }


### PR DESCRIPTION
I have had several cases where the inheritance mode checking for a family with a few tens of thousands of variants was taking minutes to process. This appears to be a GC and autoboxing issue as there was plenty of free RAM, yet the CPU was spending about 40% of its time on this method:

```java
public boolean isNotObserved() {
    return alleleNumbers.stream().allMatch(n -> n == NO_CALL);
} 
```
Internally this creates a new Stream and then auto-unboxes 'n' to compare against 'NO_CALL' each time the method is called. This was also being called multiple times internally to calculate other boolean values.

When looked at in the context of the application all the 'Genotype' methods were being called many, many times during the inheritance mode checking. Replacing the results of these calculations with a one-off pre-calculation seems a better option, which is what this PR does. Given the potential quantity of these objects being created I opted for using primitives over Streams, even though the latter is often easier to read (depending on personal taste).
