### PR TITLE
Fix right-shifting deletions on AA sequence (fixes #498)

### DIFF
--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java
@@ -136,7 +136,7 @@ public final class DeletionAnnotationBuilder extends AnnotationBuilder {
 			final String insAA = varAASeq.substring(changeBeginPos.getPos() / 3, varAAEndPos);
 			this.aaChange = new AminoAcidChange(changeBeginPos.getPos() / 3, delAA, insAA);
 			this.aaChange = AminoAcidChangeNormalizer.truncateBothSides(this.aaChange);
-			this.aaChange = AminoAcidChangeNormalizer.normalizeDeletion(wtAASeq, this.aaChange);
+			this.aaChange = AminoAcidChangeNormalizer.normalizeDeletion(wtAASeq, varAASeq, this.aaChange);
 		}
 
 		public Annotation build() {

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/AminoAcidChangeNormalizer.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/reference/AminoAcidChangeNormalizer.java
@@ -26,18 +26,18 @@ public final class AminoAcidChangeNormalizer {
 	 * Return <code>change</code> if it is not a clean deletion.
 	 *
 	 * @param ref    reference amino acid string to change
+	 * @param alt    alternated amino acid string to compare
 	 * @param change the {@link AminoAcidChange} to normalize
 	 * @return normalized AminoAcidChange
 	 */
-	public static AminoAcidChange normalizeDeletion(String ref, AminoAcidChange change) {
-		if (change.getRef().length() == 0 || change.getAlt().length() != 0)
+	public static AminoAcidChange normalizeDeletion(String ref, String alt, AminoAcidChange change) {
+		if (change.getRef().length() == 0)
 			return change;
 
 		// Compute shift of deletion.
 		int shift = 0;
-		final int LEN = change.getRef().length();
-		while (change.getPos() + LEN + shift < ref.length()
-			&& ref.charAt(change.getPos()) == ref.charAt(change.getPos() + LEN + shift))
+		while (change.getPos() + shift < ref.length() && change.getPos() + shift < alt.length()
+				&& ref.charAt(change.getPos() + shift) == alt.charAt(change.getPos() + shift))
 			shift += 1;
 		if (shift == 0)
 			return change;
@@ -45,7 +45,9 @@ public final class AminoAcidChangeNormalizer {
 		// Build new AminoAcidChange.
 		StringBuilder changeRefBuilder = new StringBuilder();
 		changeRefBuilder.append(ref.substring(change.getPos() + shift, change.getPos() + shift + change.getRef().length()));
-		return new AminoAcidChange(change.getPos() + shift, changeRefBuilder.toString(), "");
+		StringBuilder changeAltBuilder = new StringBuilder();
+		changeAltBuilder.append(alt.substring(change.getPos() + shift, change.getPos() + shift + change.getAlt().length()));
+		return new AminoAcidChange(change.getPos() + shift, changeRefBuilder.toString(), changeAltBuilder.toString());
 	}
 
 	/**

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilderTest.java
@@ -327,6 +327,20 @@ public class DeletionAnnotationBuilderTest {
 	}
 
 	@Test
+	public void testForwardInternalFrameShiftNormalization() throws InvalidGenomeVariant {
+		// The following starts with a codon but still causes a shift in the nucleotide sequence.
+		GenomeVariant change1 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6645991,
+				PositionType.ZERO_BASED), "GAGAAACCCT", "");
+		Annotation annotation1 = new DeletionAnnotationBuilder(infoForward, change1, new AnnotationBuilderOptions())
+				.build();
+		Assert.assertEquals(infoForward.getAccession(), annotation1.getTranscript().getAccession());
+		Assert.assertEquals(3, annotation1.getAnnoLoc().getRank());
+		Assert.assertEquals("946_955del", annotation1.getCDSNTChange().toHGVSString());
+		Assert.assertEquals("(Glu316Leufs*25)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
+		Assert.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_TRUNCATION), annotation1.getEffects());
+	}
+
+	@Test
 	public void testForwardNonFrameShiftDeletion() throws InvalidGenomeVariant {
 		// clean (FS of begin position is 0) deletion of one codon, starting in intron (thus no "exon3" annotation is
 		// generated).

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/AminoAcidChangeTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/reference/AminoAcidChangeTest.java
@@ -13,42 +13,56 @@ public class AminoAcidChangeTest {
 
 	@Before
 	public void setUp() throws Exception {
-		this.ref = "AAACCCAAACCC";
-		this.ref2 = "CATCATCTTCA";
+		this.ref = "LLLCCCLLLCCC";
+		this.ref2 = "CLTCLTCTTCL";
 	}
 
 	@Test
 	public void testShiftNoRefChange() {
 		AminoAcidChange origChange = new AminoAcidChange(3, "CC", "");
-		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, origChange);
+		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, "LLLCLLLCCC", origChange);
 		Assert.assertEquals(new AminoAcidChange(4, "CC", ""), modChange);
 	}
 
 	@Test
 	public void testShiftNoRefChangeEnd() {
 		AminoAcidChange origChange = new AminoAcidChange(9, "CC", "");
-		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, origChange);
+		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, "LLLCCCLLLC", origChange);
 		Assert.assertEquals(new AminoAcidChange(10, "CC", ""), modChange);
 	}
 
 	@Test
 	public void testShiftRefChange() {
-		AminoAcidChange origChange = new AminoAcidChange(3, "CAT", "");
-		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref2, origChange);
-		Assert.assertEquals(new AminoAcidChange(4, "ATC", ""), modChange);
+		AminoAcidChange origChange = new AminoAcidChange(3, "CLT", "");
+		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref2, "CLTCTTCL", origChange);
+		Assert.assertEquals(new AminoAcidChange(4, "LTC", ""), modChange);
+	}
+
+	@Test
+	public void testShiftFrameshiftNoInsAA() {
+		AminoAcidChange origChange = new AminoAcidChange(3, "CQY", "");
+		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion("LLLCQYCLLL", "LLLCQYVA", origChange);
+				Assert.assertEquals(new AminoAcidChange(6, "CLL", ""), modChange);
+	}
+
+	@Test
+	public void testShiftFrameshiftInsAA() {
+		AminoAcidChange origChange = new AminoAcidChange(3, "CQY", "C");
+		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion("LLLCQYCLLL", "LLLCQYVA", origChange);
+		Assert.assertEquals(new AminoAcidChange(6, "CLL", "V"), modChange);
 	}
 
 	@Test
 	public void testNoShift() {
 		AminoAcidChange origChange = new AminoAcidChange(3, "CCC", "");
-		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, origChange);
+		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, "LLLLLLCCC", origChange);
 		Assert.assertEquals(new AminoAcidChange(3, "CCC", ""), modChange);
 	}
 
 	@Test
 	public void testNoShiftEnd() {
 		AminoAcidChange origChange = new AminoAcidChange(9, "CCC", "");
-		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, origChange);
+		AminoAcidChange modChange = AminoAcidChangeNormalizer.normalizeDeletion(ref, "LLLCCCLLL", origChange);
 		Assert.assertEquals(new AminoAcidChange(9, "CCC", ""), modChange);
 	}
 


### PR DESCRIPTION
(see #498 for a summary and a nicer explanation with links to the affected source code)

## Problem

The previous code addressed the problems with deletions introducing frameshifts by avoiding right-shifting in those cases altogether, by checking `change.getAlt().length() != 0` in `AminoAcidChangeNormalizer#normalizeDeletion`. This may be wrong if the frame-shifted sequence introduces the same amino acid(s) that would have followed in the wild type as well.

It also does not address the following corner case:

- consider a deletion coinciding with the start of a codon, so that `changeBeginPos.getFrameshift() == 0` in the calling code
(`DeletionAnnotationBuilder`), which means that `insAA` will be empty and thus normalization will be attempted by
`AminoAcidChangeNormalizer#normalizeDeletion`

- assume the length of the deletion is not divisible by three, so it will itself introduce a frameshift, so that `varAASeq` (the AA sequence containing the variant) will differ significantly from from `wtAASeq` (the wildtype AA sequence) at the position of the deletion (and downstream)

- since `AminoAcidChangeNormalizer#normalizeDeletion` only operates on the wildtype AA sequence (`wtAASeq`), this goes unnoticed, and in case the sequence of deleted amino acids starts with the same amino acid(s) as those after the deletion in the wild type, the variant will be erroneously right-shifted on that wild-type sequence (the right-shifting currently did not consider `varAASeq` at all)

## Example

```
      H | T | G | E | K | P |fs F| E | C |
GGAAACAT|ACT|GGG|GAG|AAA|CCC| TTT|GAG|TGT|CCCAAATGTGGGAAGTGTTACTTTCGG...
GGAAACAT|ACT|GGG|---|---|---|-TTG|AGT|GTC|CCAAATGT..
                            |  L | S | V |
```

Before `AminoAcidChangeNormalizer#normalizeDeletion` gets called, `AminoAcidChange` will be `'EKPF'>''`. However, due to the above problem this will be right-shifted to `'KPFE'>''`, which leads to a wrong position and a wrong AA displayed in the variant's protein change HGVS annotation.

In this example, the protein change should be `p.(Glu316Leufs*25)` (in one-letter codes, `p.(E316Lfs*25)`) but is erroneously changed to `p.(Lys317Serfs*24)` (`p.(K317Sfs*24)`).

## Solution

In contrast to the right-shifting code for nucleotides, it seems a better approach here would be to simply compare both wild-type and variant AA sequence, as they already have been computed by the `AminoAcidChangeNormalizer` anyhow. So, `varAASeq` is now passed into `AminoAcidChangeNormalizer#normalizeDeletion` and compared to the wildtype AA sequence. This also allows us to apply right-shifting to deletions that do not coincide with the beginning of a codon.

## Tests

This adds both an 'integration' test with the above example to `DeletionAnnotationBuilderTest` and some unit tests to 
`AminoAcidChangeTest`. The latter has also been adjusted to make it clear that the tested operations should work on AA sequences, not nucleotide sequences (globally replaced 'A' by 'L'). 

Also note that at least one test (`testRealWorldCase_uc011mcs_()`) is failing with the changes introduced here. I'm not sure if this is a problem with the test or with my code, but from looking at the difference between expected and actual outcome, it seems the current test data is wrong (but I wanted to confirm the whole issue first, before digging in deeper).

## to do

_(not sure whether I should be doing this, but these points should be resolved before a merge)_

- [ ] confirm this is an issue and the approach taken here is reasonable
- [ ] adjust test data so that tests pass
- [ ] adjust (and test) other areas with a similar issue, in particular check `InsertionAnnotationBuilder` 