### PR TITLE
Allow disabling 3' Shifting in the rest server 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Argument `--no-3-prime-shifting` had inverse meaning (#552).
   This has been fixed now.
+- Hook `--no-3-prime-shifting` argument with the rest server.
+  If shifting is enabled, `?no-3-prime-shifting` can be sent as a query param in the API request to temporarily
+  disable the shifting.
 
 ## v0.39
 

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/rest_server/RestServerCommand.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/rest_server/RestServerCommand.java
@@ -53,6 +53,7 @@ public class RestServerCommand extends JannovarAnnotationCommand {
 		System.err.println("Options: " + options);
 		ipAddress(options.getHost());
 		port(options.getPort());
+		final boolean isNt3PrimeShifting = options.isNt3PrimeShifting();
 
 		System.err.println("Loading database");
 		final ImmutableMap<String, JannovarData> jvDatas = loadDatabases();
@@ -66,9 +67,11 @@ public class RestServerCommand extends JannovarAnnotationCommand {
 
 				final String key = Joiner.on("/")
 					.join(req.params(":release"), req.params(":database"));
+				final boolean threePrimeShifting = !req.queryMap().hasKey("no-3-prime-shifting") && isNt3PrimeShifting;
+
 				final JannovarData jvData = jvDatas.get(key);
 				final VariantAnnotator annotator = new VariantAnnotator(jvData.getRefDict(),
-					jvData.getChromosomes(), new AnnotationBuilderOptions(true, false));
+					jvData.getChromosomes(), new AnnotationBuilderOptions(threePrimeShifting, false));
 
 				final Integer boxedInt = jvData.getRefDict().getContigNameToID().get(chromosome);
 				if (boxedInt == null) {

--- a/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/rest_server/RestServerOptions.java
+++ b/jannovar-cli/src/main/java/de/charite/compbio/jannovar/cmd/rest_server/RestServerOptions.java
@@ -37,6 +37,12 @@ public class RestServerOptions extends JannovarBaseOptions {
 	private int port = 5050;
 
 	/**
+	 * whether or not to shift variants towards the 3' end of the transcript
+	 * (default is <code>true</code>)
+	 */
+	private boolean nt3PrimeShifting=true;
+
+	/**
 	 * Setup {@link ArgumentParser}
 	 *
 	 * @param subParsers {@link Subparsers} to setup
@@ -74,6 +80,7 @@ public class RestServerOptions extends JannovarBaseOptions {
 		host = args.getString("host");
 		port = args.getInt("port");
 		dbPaths = args.getList("database");
+		nt3PrimeShifting = args.getBoolean("3_prime_shifting");
 	}
 
 	public List<String> getDbPaths() {
@@ -100,9 +107,17 @@ public class RestServerOptions extends JannovarBaseOptions {
 		this.port = port;
 	}
 
+	public boolean isNt3PrimeShifting() {
+		return nt3PrimeShifting;
+	}
+
+	public void setNt3PrimeShifting(boolean nt3PrimeShifting) {
+		this.nt3PrimeShifting = nt3PrimeShifting;
+	}
+
 	@Override public String toString() {
 		return "RestServerOptions{" + "dbPaths=" + dbPaths + ", host='" + host + '\'' + ", port="
-			+ port + '}';
+			+ port + ", 3-prime-shifting=" + nt3PrimeShifting + '}';
 	}
 
 }


### PR DESCRIPTION
@holtgrewe, 

I work on  @CarlosBorroto 's team, and this PR is continuing the discussion on #551 . I saw that there's a fix(#553) to enable `--no-3-prime-shifting` argument for  `annotate-pos` command, thanks for fixing it!  In our use cases,  we use the rest server to annotate variants., so we are hoping to have an option to disable 3' shifting on the rest server as well. 

We noticed that  when running `rest-server` command, `--no-3-prime-shifting` is already an optional argument.
```bash
MDMBJALIU:target jliu$ java -jar jannovar-cli-0.40-SNAPSHOT.jar rest-server --help
usage: jannovar-cli rest-server [-h] [--host HOST] [--port PORT] -d DATABASE [--show-all] [--no-3-prime-shifting] [--3-letter-amino-acids] [--version] [--report-no-progress] [-v] [-vv] [--http-proxy HTTP_PROXY]
                    [--https-proxy HTTPS_PROXY] [--ftp-proxy FTP_PROXY]
```
 it's just not actually being hooked up yet. So in this PR, we proposed a change to enable `--no-3-prime-shifting` in the rest server: 
- [ ]  Enable `--no-3-prime-shifting` argument in the Rest Server. 
To disable shifting variants towards the 3' end of the transcript, run the rest server with `--no-3-prime-shifting` argument. 
For example, 
```java -jar jannovar-cli-0.40-SNAPSHOT.jar rest-server -d data/hg19_refseq.ser --no-3-prime-shifting```

Additionally, we proposed a new query param that allow a user to disable 3 prime shifting in an api request. 
- [ ] Accept `no-3-prime-shifting` as an api query param to temporarily disable 3 prime shifting.
For example, 
```https://{base_url}/annotate-var/refseq/hg19/chrX/108924495/C/CTTA?no-3-prime-shifting```
Notice that this query param is only for disabling 3' shifting, so if will only take effect if the rest server is running with 3' shift enabled.

Please let me know your thoughts on the changes or  if I miss anything. Thank you! 