### PR TITLE
Annotate coding insertions for splicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.40-SNAPSHOT (unreleased)
 
+### jannovar-core
+- Coding insertions are now annotated for splicing (#554)
+
 ### jannovar-cli
 
 - Argument `--no-3-prime-shifting` had inverse meaning (#552).

--- a/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
+++ b/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilder.java
@@ -212,6 +212,16 @@ public final class InsertionAnnotationBuilder extends AnnotationBuilder {
 				handleFrameShiftCaseWTStartWithStopCodon();
 			else
 				handleFrameShiftCaseWTStartsWithNoStopCodon();
+
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
+			final GenomePosition pos = change.getGenomePos();
+			final GenomePosition lPos = change.getGenomePos().shifted(-1);
+			if ((so.liesInSpliceDonorSite(lPos) && so.liesInSpliceDonorSite(pos)))
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
+			else if ((so.liesInSpliceAcceptorSite(lPos) && so.liesInSpliceAcceptorSite(pos)))
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
+			else if ((so.liesInSpliceRegion(lPos) && so.liesInSpliceRegion(pos)))
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 		}
 
 		/**
@@ -303,6 +313,16 @@ public final class InsertionAnnotationBuilder extends AnnotationBuilder {
 				handleNonFrameShiftCaseStartsWithStopCodon();
 			else
 				handleNonFrameShiftCaseStartsWithNoStopCodon();
+
+			// Check for being a splice site variant. The splice donor, acceptor, and region intervals are disjoint.
+			final GenomePosition pos = change.getGenomePos();
+			final GenomePosition lPos = change.getGenomePos().shifted(-1);
+			if ((so.liesInSpliceDonorSite(lPos) && so.liesInSpliceDonorSite(pos)))
+				varTypes.add(VariantEffect.SPLICE_DONOR_VARIANT);
+			else if ((so.liesInSpliceAcceptorSite(lPos) && so.liesInSpliceAcceptorSite(pos)))
+				varTypes.add(VariantEffect.SPLICE_ACCEPTOR_VARIANT);
+			else if ((so.liesInSpliceRegion(lPos) && so.liesInSpliceRegion(pos)))
+				varTypes.add(VariantEffect.SPLICE_REGION_VARIANT);
 		}
 
 		private void handleNonFrameShiftCaseStartsWithStopCodon() {

--- a/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
+++ b/jannovar-core/src/test/java/de/charite/compbio/jannovar/annotation/builders/InsertionAnnotationBuilderTest.java
@@ -729,6 +729,30 @@ public class InsertionAnnotationBuilderTest {
 		Assertions.assertEquals("?", annoInsertionBeforeExon3.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
 		Assertions.assertEquals(ImmutableSortedSet.of(VariantEffect.SPLICE_ACCEPTOR_VARIANT,
 			VariantEffect.CODING_TRANSCRIPT_INTRON_VARIANT), annoInsertionBeforeExon3.getEffects());
+
+		// coding insertion within splice region (frameshift)
+		GenomeVariant varInsertionInSpliceRegion1 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6641358,
+			PositionType.ZERO_BASED), "", "C");
+		Annotation annoInsertionInSpliceRegion1 = new InsertionAnnotationBuilder(infoForward, varInsertionInSpliceRegion1,
+			new AnnotationBuilderOptions()).build();
+		Assertions.assertEquals(infoForward.getAccession(), annoInsertionInSpliceRegion1.getTranscript().getAccession());
+		Assertions.assertEquals(1, annoInsertionInSpliceRegion1.getAnnoLoc().getRank());
+		Assertions.assertEquals("689_690insC", annoInsertionInSpliceRegion1.getCDSNTChange().toHGVSString());
+		Assertions.assertEquals("(Glu230Aspfs*11)", annoInsertionInSpliceRegion1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER)); // XXX
+		Assertions.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT,
+			VariantEffect.SPLICE_REGION_VARIANT), annoInsertionInSpliceRegion1.getEffects());
+
+		// coding insertion within splice region (no frameshift)
+		GenomeVariant varInsertionInSpliceRegion2 = new GenomeVariant(new GenomePosition(refDict, Strand.FWD, 1, 6641358,
+			PositionType.ZERO_BASED), "", "CTC");
+		Annotation annoInsertionInSpliceRegion2 = new InsertionAnnotationBuilder(infoForward, varInsertionInSpliceRegion2,
+			new AnnotationBuilderOptions()).build();
+		Assertions.assertEquals(infoForward.getAccession(), annoInsertionInSpliceRegion2.getTranscript().getAccession());
+		Assertions.assertEquals(1, annoInsertionInSpliceRegion2.getAnnoLoc().getRank());
+		Assertions.assertEquals("689_690insCTC", annoInsertionInSpliceRegion2.getCDSNTChange().toHGVSString());
+		Assertions.assertEquals("(Glu230delinsAspSer)", annoInsertionInSpliceRegion2.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER)); // XXX
+		Assertions.assertEquals(ImmutableSortedSet.of(VariantEffect.DISRUPTIVE_INFRAME_INSERTION,
+			VariantEffect.SPLICE_REGION_VARIANT), annoInsertionInSpliceRegion2.getEffects());
 	}
 
 	@Test
@@ -1493,7 +1517,8 @@ public class InsertionAnnotationBuilderTest {
 		Assertions.assertEquals(7, annotation1.getAnnoLoc().getRank());
 		Assertions.assertEquals("730_731insT", annotation1.getCDSNTChange().toHGVSString());
 		Assertions.assertEquals("(Asn244Ilefs*52)", annotation1.getProteinChange().toHGVSString(AminoAcidCode.THREE_LETTER));
-		Assertions.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT), annotation1.getEffects());
+		Assertions.assertEquals(ImmutableSortedSet.of(VariantEffect.FRAMESHIFT_VARIANT,
+			VariantEffect.SPLICE_REGION_VARIANT), annotation1.getEffects());
 	}
 
 	/**


### PR DESCRIPTION
Fixes #554 
In this issue, we discovered that deletions are annotated for splicing -- both coding ([here](https://github.com/charite/jannovar/blob/main/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java#L156-L162) and [here](https://github.com/charite/jannovar/blob/main/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/DeletionAnnotationBuilder.java#L205-L211)) and [non-coding](https://github.com/charite/jannovar/blob/main/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java#L162-L189). However, for insertions, only [non-coding](https://github.com/charite/jannovar/blob/main/jannovar-core/src/main/java/de/charite/compbio/jannovar/annotation/builders/AnnotationBuilder.java#L162-L189) insertions are annotated for splicing. 

In this PR , we went ahead adding the code for coding insertion. We also included some test case as well.

cc @CarlosBorroto, @dmb107